### PR TITLE
Added BurrowDetect (new Module)

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -55,6 +55,7 @@ public class AresMod extends Ares {
                 AutoTotem.class,
                 //AutoTrap.class,
                 BowRelease.class,
+                BurrowDetect.class,
                 Criticals.class,
                 //HoleFiller.class,
                 //HopperAura.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/BurrowDetect.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/BurrowDetect.java
@@ -1,0 +1,63 @@
+package dev.tigr.ares.fabric.impl.modules.combat;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.util.render.TextColor;
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Hoosiers, 11/25/2020
+ */
+
+@Module.Info(name = "BurrowDetect", description = "Sends a message in chat whenever a player is burrowed", category = Category.COMBAT)
+public class BurrowDetect extends Module {
+
+    private final List<PlayerEntity> burrowedPlayers = new ArrayList<>();
+
+    @Override
+    public void onTick(){
+
+        for (PlayerEntity playerEntity : MC.world.getPlayers().stream().filter(entityPlayer -> entityPlayer != MC.player).collect(Collectors.toList())){
+            if (!burrowedPlayers.contains(playerEntity) && isInBurrow(playerEntity)){
+                UTILS.printMessage(TextColor.BLUE + playerEntity.getEntityName() + TextColor.GREEN + " has burrowed!");
+                burrowedPlayers.add(playerEntity);
+            }
+        }
+
+        for (PlayerEntity playerEntity : burrowedPlayers){
+            if (!isInBurrow(playerEntity)){
+                UTILS.printMessage(TextColor.BLUE + playerEntity.getEntityName() + TextColor.RED + " is no longer burrowed!");
+                burrowedPlayers.remove(playerEntity);
+            }
+        }
+    }
+
+    private boolean isInBurrow(PlayerEntity playerEntity){
+        BlockPos playerPos = new BlockPos(getMiddlePosition(playerEntity.getX()), playerEntity.getY(), getMiddlePosition(playerEntity.getZ()));
+
+        return MC.world.getBlockState(playerPos).getBlock() == Blocks.OBSIDIAN
+                || MC.world.getBlockState(playerPos).getBlock() == Blocks.ENDER_CHEST
+                || MC.world.getBlockState(playerPos).getBlock() == Blocks.ANVIL;
+    }
+
+    //This converts a double position such as 12.9 or 12.13 to a "middle" value of 12.5
+    private double getMiddlePosition(double positionIn){
+        double positionFinal = positionIn;
+
+
+        if (Math.round(positionIn) > positionIn){
+            positionFinal -= 0.5;
+        }
+        else if (Math.round(positionIn) < positionIn){
+            positionFinal += 0.5;
+        }
+
+        return positionFinal;
+    }
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
@@ -65,6 +65,7 @@ public class AresMod extends Ares {
                 AutoTotem.class,
                 AutoTrap.class,
                 BowRelease.class,
+                BurrowDetect.class,
                 Criticals.class,
                 CrystalAura.class,
                 HoleFiller.class,

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/BurrowDetect.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/BurrowDetect.java
@@ -1,0 +1,63 @@
+package dev.tigr.ares.forge.impl.modules.combat;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.util.render.TextColor;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Hoosiers, 11/25/2020
+ */
+
+@Module.Info(name = "BurrowDetect", description = "Sends a message in chat whenever a player is burrowed", category = Category.COMBAT)
+public class BurrowDetect extends Module {
+
+    private final List<EntityPlayer> burrowedPlayers = new ArrayList<>();
+
+    @Override
+    public void onTick(){
+
+        for (EntityPlayer entityPlayer : MC.world.playerEntities.stream().filter(entityPlayer -> entityPlayer != MC.player).collect(Collectors.toList())){
+            if (!burrowedPlayers.contains(entityPlayer) && isInBurrow(entityPlayer)){
+                UTILS.printMessage(TextColor.BLUE + entityPlayer.getDisplayNameString() + TextColor.GREEN + " has burrowed!");
+                burrowedPlayers.add(entityPlayer);
+            }
+        }
+
+        for (EntityPlayer entityPlayer : burrowedPlayers){
+            if (!isInBurrow(entityPlayer)){
+                UTILS.printMessage(TextColor.BLUE + entityPlayer.getDisplayNameString() + TextColor.RED + " is no longer burrowed!");
+                burrowedPlayers.remove(entityPlayer);
+            }
+        }
+    }
+
+    private boolean isInBurrow(EntityPlayer entityPlayer){
+        BlockPos playerPos = new BlockPos(getMiddlePosition(entityPlayer.posX), entityPlayer.posY, getMiddlePosition(entityPlayer.posZ));
+
+        return MC.world.getBlockState(playerPos).getBlock() == Blocks.OBSIDIAN
+                || MC.world.getBlockState(playerPos).getBlock() == Blocks.ENDER_CHEST
+                || MC.world.getBlockState(playerPos).getBlock() == Blocks.ANVIL;
+    }
+
+    //This converts a double position such as 12.9 or 12.13 to a "middle" value of 12.5
+    private double getMiddlePosition(double positionIn){
+        double positionFinal = positionIn;
+
+
+        if (Math.round(positionIn) > positionIn){
+            positionFinal -= 0.5;
+        }
+        else if (Math.round(positionIn) < positionIn){
+            positionFinal += 0.5;
+        }
+
+        return positionFinal;
+    }
+}


### PR DESCRIPTION
### This module is for both versions: forge and fabric

**Description**: BurrowDetect is a new combat module, similar to VisualRange or TotemPopCounter, in that it sends a client message when a player in render distance is "burrowed". This can be defined as a player's feet position is inside a block such as obsidian, ender chests, or anvils.

**Why is this useful?** This helps to combat recent "meta" changes by alerting the user before they try to jump in a player's now burrowed hole.

**Is it future proof?** Ideally, yes. This module covers the common obsidian burrow traps along with some less common methods using ender chests and anvils. This means that this module will still be useful if obsidian-burrows are patched.

### Testing

Versions tested on: Forge version 14.23.5.2854 and Fabric version 0.10.6 build 214

This module is relatively easy to test with a fake player and vanilla /fill commands.