### PR TITLE
Ported TotemPopCounter, NoSwing

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -64,7 +64,7 @@ public class AresMod extends Ares {
                 //Offhand.class,
                 //OffhandGap.class,
                 //Surround.class,
-                //TotemPopCounter.class,
+                TotemPopCounter.class,
 
                 // hud
                 Armor.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -87,7 +87,7 @@ public class AresMod extends Ares {
                 //NewChunks.class,
                 NoBreakDelay.class,
                 NoBreakReset.class,
-                //NoSwing.class,
+                NoSwing.class,
                 //PacketCancel.class,
                 PortalGodMode.class,
                 SecretClose.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/player/DamageBlockEvent.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/player/DamageBlockEvent.java
@@ -1,0 +1,25 @@
+package dev.tigr.ares.fabric.event.player;
+
+import dev.tigr.simpleevents.event.Event;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+/**
+ * @author Hoosiers on 11/26/20
+ */
+
+public class DamageBlockEvent extends Event {
+    private final BlockPos blockPos;
+    private final Direction direction;
+
+    public DamageBlockEvent(BlockPos blockPos, Direction direction) {
+        this.blockPos = blockPos;
+        this.direction = direction;
+    }
+
+    public BlockPos getBlockPos() {
+        return blockPos;
+    }
+
+    public Direction getDirection(){return direction;}
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/BurrowDetect.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/BurrowDetect.java
@@ -25,14 +25,14 @@ public class BurrowDetect extends Module {
 
         for (PlayerEntity playerEntity : MC.world.getPlayers().stream().filter(entityPlayer -> entityPlayer != MC.player).collect(Collectors.toList())){
             if (!burrowedPlayers.contains(playerEntity) && isInBurrow(playerEntity)){
-                UTILS.printMessage(TextColor.BLUE + playerEntity.getEntityName() + TextColor.GREEN + " has burrowed!");
+                UTILS.printMessage(TextColor.BLUE + playerEntity.getEntityName() + TextColor.GREEN + " has burrowed");
                 burrowedPlayers.add(playerEntity);
             }
         }
 
         for (PlayerEntity playerEntity : burrowedPlayers){
             if (!isInBurrow(playerEntity)){
-                UTILS.printMessage(TextColor.BLUE + playerEntity.getEntityName() + TextColor.RED + " is no longer burrowed!");
+                UTILS.printMessage(TextColor.BLUE + playerEntity.getEntityName() + TextColor.RED + " is no longer burrowed");
                 burrowedPlayers.remove(playerEntity);
             }
         }
@@ -48,13 +48,12 @@ public class BurrowDetect extends Module {
 
     //This converts a double position such as 12.9 or 12.13 to a "middle" value of 12.5
     private double getMiddlePosition(double positionIn){
-        double positionFinal = positionIn;
-
+        double positionFinal = Math.round(positionIn);
 
         if (Math.round(positionIn) > positionIn){
             positionFinal -= 0.5;
         }
-        else if (Math.round(positionIn) < positionIn){
+        else if (Math.round(positionIn) <= positionIn){
             positionFinal += 0.5;
         }
 

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/TotemPopCounter.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/TotemPopCounter.java
@@ -1,0 +1,62 @@
+package dev.tigr.ares.fabric.impl.modules.combat;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.util.render.TextColor;
+import dev.tigr.ares.fabric.event.client.LivingDeathEvent;
+import dev.tigr.ares.fabric.event.client.PacketEvent;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.packet.s2c.play.EntityStatusS2CPacket;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author Tigermouthbear 7/13/20
+ * ported to Fabric by Hoosiers 11/26/20
+ */
+
+@Module.Info(name = "TotemPopCounter", description = "Counts the amount of totem pops a player has had in chat", category = Category.COMBAT)
+public class TotemPopCounter extends Module {
+    // name, count
+    private final Map<String, Integer> popMap = new HashMap<>();
+
+    @EventHandler
+    public EventListener<PacketEvent.Receive> packetReceiveEvent = new EventListener<>(event -> {
+        if(MC.player != null && event.getPacket() instanceof EntityStatusS2CPacket) {
+            EntityStatusS2CPacket status = (EntityStatusS2CPacket) event.getPacket();
+            if(status.getStatus() == 35) {
+                Entity entity = status.getEntity(MC.world);
+                if(!(entity instanceof PlayerEntity) || entity == MC.player) return;
+
+                int amount = popMap.getOrDefault(entity.getEntityName(), 0) + 1;
+                popMap.put(entity.getEntityName(), amount);
+                UTILS.printMessage(TextColor.BLUE + entity.getEntityName() + TextColor.WHITE + " has popped " + amount + " totems");
+            }
+        }
+    });
+
+    @EventHandler
+    public EventListener<LivingDeathEvent> deathEvent = new EventListener<>(event -> {
+        if(popMap.containsKey(event.getEntity().getEntityName())) popMap.put(event.getEntity().getEntityName(), 0);
+    });
+
+    @Override
+    public void onTick() {
+        // only do this 2 times a second
+        if(MC.player.age % 10 != 0) return;
+
+        popMap.keySet().forEach(entity -> {
+            Optional<AbstractClientPlayerEntity> optionalPlayerEntity = MC.world.getPlayers().stream().filter(playerEntity -> playerEntity.getEntityName().equals(entity)).findFirst();
+            if(optionalPlayerEntity.isPresent()) {
+                PlayerEntity player = optionalPlayerEntity.get();
+                if(player.isDead() || player.getHealth() <= 0) popMap.put(entity, 0);
+            }
+        });
+    }
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/NoSwing.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/NoSwing.java
@@ -1,48 +1,50 @@
-package dev.tigr.ares.forge.impl.modules.exploit;
+package dev.tigr.ares.fabric.impl.modules.exploit;
 
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
 import dev.tigr.ares.core.setting.settings.EnumSetting;
-import dev.tigr.ares.forge.event.events.player.DamageBlockEvent;
-import dev.tigr.ares.forge.event.events.player.PacketEvent;
+import dev.tigr.ares.fabric.event.client.PacketEvent;
+import dev.tigr.ares.fabric.event.player.DamageBlockEvent;
 import dev.tigr.simpleevents.listener.EventHandler;
 import dev.tigr.simpleevents.listener.EventListener;
-import net.minecraft.init.Blocks;
-import net.minecraft.network.play.client.CPacketAnimation;
-import net.minecraft.network.play.client.CPacketPlayerDigging;
+import net.minecraft.block.Blocks;
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
+import net.minecraft.network.packet.s2c.play.EntityAnimationS2CPacket;
 import net.minecraft.util.math.BlockPos;
 
 /**
  * @author Tigermouthbear
+ * ported to Fabric by Hoosiers 11/26/20
  */
+
 @Module.Info(name = "NoSwing", description = "Prevents the swing animation for others", category = Category.EXPLOIT)
 public class NoSwing extends Module {
     private final Setting<Mode> mode = register(new EnumSetting<>("Mode", Mode.NO_ANIMATION));
-    
+
     @EventHandler
     public EventListener<PacketEvent.Sent> packetSentEvent = new EventListener<>(event -> {
-        if(mode.getValue() == Mode.NO_ANIMATION && event.getPacket() instanceof CPacketAnimation)
+        if(mode.getValue() == Mode.NO_ANIMATION && event.getPacket() instanceof EntityAnimationS2CPacket)
             event.setCancelled(true);
     });
 
     //Migrating away from a forge event will help with porting to Fabric -Hoosiers
     @EventHandler
-    public EventListener<DamageBlockEvent> damageBlockEventEventListener = new EventListener<>(event -> {
+    public EventListener<DamageBlockEvent> damageBlockEvent = new EventListener<>(event -> {
         if (mode.getValue() != Mode.PACKET_MINE){
             return;
         }
 
-        if (MC.gameSettings.keyBindAttack.isKeyDown() && MC.objectMouseOver.entityHit == null){
+        if (MC.options.keyAttack.isPressed() && MC.targetedEntity == null){
             if (canBreakBlock(event.getBlockPos())) {
-                MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, event.getBlockPos(), event.getEnumFacing()));
-                MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.STOP_DESTROY_BLOCK, event.getBlockPos(), event.getEnumFacing()));
+                MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, event.getBlockPos(), event.getDirection()));
+                MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, event.getBlockPos(), event.getDirection()));
                 event.setCancelled(true);
             }
         }
     });
 
-    //We don't want to try to break something that is unbreakable
+    //we don't want to try to break something that is unbreakable
     private boolean canBreakBlock(BlockPos blockPos){
         return !(MC.world.getBlockState(blockPos).getBlock() == Blocks.BEDROCK) || !(MC.world.getBlockState(blockPos).getBlock() == Blocks.BARRIER);
     }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerInteractionManager.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerInteractionManager.java
@@ -2,11 +2,15 @@ package dev.tigr.ares.fabric.mixin.client;
 
 import dev.tigr.ares.core.Ares;
 import dev.tigr.ares.fabric.event.client.ResetBlockRemovingEvent;
+import dev.tigr.ares.fabric.event.player.DamageBlockEvent;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * @author Tigermouthbear
@@ -17,5 +21,12 @@ public class MixinClientPlayerInteractionManager {
     private void resetBlockWrapper(CallbackInfo ci) {
         ResetBlockRemovingEvent event = Ares.EVENT_MANAGER.post(new ResetBlockRemovingEvent());
         if(Ares.EVENT_MANAGER.post(new ResetBlockRemovingEvent()).isCancelled()) ci.cancel();
+    }
+
+    @Inject(method = "updateBlockBreakingProgress", at = @At("HEAD"), cancellable = true)
+    private void damageBlock(BlockPos blockPos, Direction direction, CallbackInfoReturnable<Boolean> cir) {
+        if (Ares.EVENT_MANAGER.post(new DamageBlockEvent(blockPos, direction)).isCancelled()){
+            cir.cancel();
+        }
     }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/player/DamageBlockEvent.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/player/DamageBlockEvent.java
@@ -1,0 +1,27 @@
+package dev.tigr.ares.forge.event.events.player;
+
+import dev.tigr.simpleevents.event.Event;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * @author Hoosiers on 11/26/2020
+ */
+
+public class DamageBlockEvent extends Event {
+    private final BlockPos blockPos;
+    private final EnumFacing enumFacing;
+
+    public DamageBlockEvent(BlockPos blockPos, EnumFacing enumFacing){
+        this.blockPos = blockPos;
+        this.enumFacing = enumFacing;
+    }
+
+    public BlockPos getBlockPos(){
+        return this.blockPos;
+    }
+
+    public EnumFacing getEnumFacing(){
+        return this.enumFacing;
+    }
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/player/DestroyBlockEvent.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/player/DestroyBlockEvent.java
@@ -1,8 +1,9 @@
 package dev.tigr.ares.forge.event.events.player;
 
+import dev.tigr.simpleevents.event.Event;
 import net.minecraft.util.math.BlockPos;
 
-public class DestroyBlockEvent {
+public class DestroyBlockEvent extends Event {
     private final BlockPos pos;
 
     public DestroyBlockEvent(BlockPos pos) {

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/BurrowDetect.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/BurrowDetect.java
@@ -25,14 +25,14 @@ public class BurrowDetect extends Module {
 
         for (EntityPlayer entityPlayer : MC.world.playerEntities.stream().filter(entityPlayer -> entityPlayer != MC.player).collect(Collectors.toList())){
             if (!burrowedPlayers.contains(entityPlayer) && isInBurrow(entityPlayer)){
-                UTILS.printMessage(TextColor.BLUE + entityPlayer.getDisplayNameString() + TextColor.GREEN + " has burrowed!");
+                UTILS.printMessage(TextColor.BLUE + entityPlayer.getDisplayNameString() + TextColor.GREEN + " has burrowed");
                 burrowedPlayers.add(entityPlayer);
             }
         }
 
         for (EntityPlayer entityPlayer : burrowedPlayers){
             if (!isInBurrow(entityPlayer)){
-                UTILS.printMessage(TextColor.BLUE + entityPlayer.getDisplayNameString() + TextColor.RED + " is no longer burrowed!");
+                UTILS.printMessage(TextColor.BLUE + entityPlayer.getDisplayNameString() + TextColor.RED + " is no longer burrowed");
                 burrowedPlayers.remove(entityPlayer);
             }
         }
@@ -48,13 +48,12 @@ public class BurrowDetect extends Module {
 
     //This converts a double position such as 12.9 or 12.13 to a "middle" value of 12.5
     private double getMiddlePosition(double positionIn){
-        double positionFinal = positionIn;
-
+        double positionFinal = Math.round(positionIn);
 
         if (Math.round(positionIn) > positionIn){
             positionFinal -= 0.5;
         }
-        else if (Math.round(positionIn) < positionIn){
+        else if (Math.round(positionIn) <= positionIn){
             positionFinal += 0.5;
         }
 

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/mixin/client/MixinPlayerControllerMP.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/mixin/client/MixinPlayerControllerMP.java
@@ -1,9 +1,11 @@
 package dev.tigr.ares.forge.mixin.client;
 
 import dev.tigr.ares.core.Ares;
+import dev.tigr.ares.forge.event.events.player.DamageBlockEvent;
 import dev.tigr.ares.forge.event.events.player.DestroyBlockEvent;
 import dev.tigr.ares.forge.event.events.player.ResetBlockRemovingEvent;
 import net.minecraft.client.multiplayer.PlayerControllerMP;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,5 +26,12 @@ public class MixinPlayerControllerMP {
     @Inject(method = "onPlayerDestroyBlock", at = @At("RETURN"))
     private void destroyBlock(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
         Ares.EVENT_MANAGER.post(new DestroyBlockEvent(pos));
+    }
+
+    @Inject(method = "onPlayerDamageBlock", at = @At("HEAD"), cancellable = true)
+    private void damageBlock(BlockPos blockPos, EnumFacing enumFacing, CallbackInfoReturnable<Boolean> cir){
+        if (Ares.EVENT_MANAGER.post(new DamageBlockEvent(blockPos, enumFacing)).isCancelled()){
+            cir.cancel();
+        }
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
* TotemPopCounter is now ported into fabric.
* NoSwing is now ported into fabric.
* The packet mine method in NoSwing has been redone.
* Minor changes were done to the BurrowDetect centering calculation.

**Additional context**
* The new packetmine method uses its own event instead of the Forge MouseEvent. This made it a lot easier to port over to Fabric and allows for it to trigger for the user's binded break key instead of a left mouse click.
* All changes were tested in their respective Forge/Fabric versions.