### PR TITLE
Fabric Port: NoFog & PacketCancel

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -88,7 +88,7 @@ public class AresMod extends Ares {
                 NoBreakDelay.class,
                 NoBreakReset.class,
                 NoSwing.class,
-                //PacketCancel.class,
+                PacketCancel.class,
                 PortalGodMode.class,
                 SecretClose.class,
                 ServerCrasher.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -147,7 +147,7 @@ public class AresMod extends Ares {
                 MobOwner.class,
                 NameTags.class,
                 NoArmorRender.class,
-                //NoFog.class,
+                NoFog.class,
                 NoHurtShake.class,
                 NoRender.class,
                 NoWeather.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/render/SetupFogEvent.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/render/SetupFogEvent.java
@@ -1,0 +1,6 @@
+package dev.tigr.ares.fabric.event.render;
+
+import dev.tigr.simpleevents.event.Event;
+
+public class SetupFogEvent extends Event {
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/PacketCancel.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/PacketCancel.java
@@ -1,0 +1,44 @@
+package dev.tigr.ares.fabric.impl.modules.exploit;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
+import dev.tigr.ares.fabric.event.client.PacketEvent;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+import net.minecraft.network.packet.c2s.play.*;
+
+/**
+ * @author Tigermouthbear
+ * ported to Fabric by Hoosiers 11/27/20
+ */
+@Module.Info(name = "PacketCancel", description = "Cancels certain packets", category = Category.EXPLOIT)
+public class PacketCancel extends Module {
+    private final Setting<Boolean> vehicleMove = register(new BooleanSetting("VehicleMoveC2SPacket", true));
+    private final Setting<Boolean> entityAction = register(new BooleanSetting("PlayerActionC2SPacket", true));
+    private final Setting<Boolean> entityInteract = register(new BooleanSetting("PlayerInteractEntityC2SPacket", true));
+    private final Setting<Boolean> playerInput = register(new BooleanSetting("PlayerInputC2SPacket", true));
+    private final Setting<Boolean> playerMove = register(new BooleanSetting("PlayerMoveC2SPacket", true));
+    private final Setting<Boolean> updatePlayerAbilities = register(new BooleanSetting("UpdatePlayerAbilitiesC2SPacket", true));
+    private final Setting<Boolean> handSwing = register(new BooleanSetting("HandSwingC2SPacket", true));
+    private final Setting<Boolean> playerInteractItem = register(new BooleanSetting("PlayerInteractItemC2SPacket", true));
+    private final Setting<Boolean> playerInteractBlock = register(new BooleanSetting("PlayerInteractBlockC2SPacket", true));
+
+    @EventHandler
+    public EventListener<PacketEvent.Sent> packetSentEvent = new EventListener<>(event -> {
+        if(event.getPacket() instanceof VehicleMoveC2SPacket && vehicleMove.getValue()) event.setCancelled(true);
+        else if(event.getPacket() instanceof PlayerActionC2SPacket && entityAction.getValue()) event.setCancelled(true);
+        else if(event.getPacket() instanceof PlayerInteractEntityC2SPacket && entityInteract.getValue()) event.setCancelled(true);
+        else if(event.getPacket() instanceof PlayerInputC2SPacket && playerInput.getValue()) event.setCancelled(true);
+        else if(event.getPacket() instanceof PlayerMoveC2SPacket && playerMove.getValue()) event.setCancelled(true);
+        else if(event.getPacket() instanceof UpdatePlayerAbilitiesC2SPacket && updatePlayerAbilities.getValue())
+            event.setCancelled(true);
+        else if(event.getPacket() instanceof HandSwingC2SPacket && handSwing.getValue())
+            event.setCancelled(true);
+        else if(event.getPacket() instanceof PlayerInteractItemC2SPacket && playerInteractItem.getValue())
+            event.setCancelled(true);
+        else if(event.getPacket() instanceof PlayerInteractBlockC2SPacket && playerInteractBlock.getValue())
+            event.setCancelled(true);
+    });
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/render/NoFog.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/render/NoFog.java
@@ -1,0 +1,16 @@
+package dev.tigr.ares.fabric.impl.modules.render;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.fabric.event.render.SetupFogEvent;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+
+/**
+ * @author Tigermouthbear
+ */
+@Module.Info(name = "NoFog", description = "Prevents rendering of fog", category = Category.RENDER)
+public class NoFog extends Module {
+    @EventHandler
+    public EventListener<SetupFogEvent> setupFogEvent = new EventListener<>(event -> event.setCancelled(true));
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/render/MixinBackgroundRenderer.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/render/MixinBackgroundRenderer.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(BackgroundRenderer.class)
 public class MixinBackgroundRenderer {
     @Inject(method = "applyFog", at = @At("HEAD"), cancellable = true)
-    private static void applyFog(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, CallbackInfo callbackInfo){
+    private static void applyFog(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, CallbackInfo callbackInfo) {
         if(Ares.EVENT_MANAGER.post(new SetupFogEvent()).isCancelled()) callbackInfo.cancel();
     }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/render/MixinBackgroundRenderer.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/render/MixinBackgroundRenderer.java
@@ -1,0 +1,21 @@
+package dev.tigr.ares.fabric.mixin.render;
+
+import dev.tigr.ares.core.Ares;
+import dev.tigr.ares.fabric.event.render.SetupFogEvent;
+import net.minecraft.client.render.BackgroundRenderer;
+import net.minecraft.client.render.Camera;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * @author Hoosiers 11/27/20
+ */
+@Mixin(BackgroundRenderer.class)
+public class MixinBackgroundRenderer {
+    @Inject(method = "applyFog", at = @At("HEAD"), cancellable = true)
+    private static void applyFog(Camera camera, BackgroundRenderer.FogType fogType, float viewDistance, boolean thickFog, CallbackInfo callbackInfo){
+        if(Ares.EVENT_MANAGER.post(new SetupFogEvent()).isCancelled()) callbackInfo.cancel();
+    }
+}

--- a/ares-fabric/src/main/resources/ares.mixins.json
+++ b/ares-fabric/src/main/resources/ares.mixins.json
@@ -17,6 +17,7 @@
     "client.MixinPlayerEntity",
     "render.MixinAbstractClientPlayerEntity",
     "render.MixinArmorFeatureRenderer",
+    "render.MixinBackgroundRenderer",
     "render.MixinCamera",
     "render.MixinCapeFeatureRenderer",
     "render.MixinElytraFeatureRenderer",


### PR DESCRIPTION
**Changes proposed in this pull request:**
-NoFog and PacketCancel modules ported to Fabric.

**Additional context**
I spent a good amount of time porting PacketCancel over to Fabric, which I tested and compared to the forge version. Along with this, I worked on adjusting the setting names to correspond with the new packet names. I feel that these might be a bit too long, let me know of any changes you think are necessary.