### PR TITLE
Added Crystal Canceller options for on hit, and on sound packet recei…

### DIFF
--- a/ares-fabric/build.gradle
+++ b/ares-fabric/build.gradle
@@ -40,8 +40,15 @@ dependencies {
     shadow "com.github.Vatuu:discord-rpc:1.6.2"
 
     // fabritone
-    implementation "com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT"
-    include "com.gitlab.CDAGaming:fabritone:fabritone~1.16.x-Fabric-SNAPSHOT"
+    implementation("com.gitlab.CDAGaming:fabritone:fabric~1.16.3-SNAPSHOT") {
+        exclude(group: "org.lwjgl.lwjgl", module: "lwjgl-platform")
+        exclude(group: "org.lwjgl.lwjgl", module: "lwjgl")
+        exclude(group: "net.java.jinput", module: "jinput-platform")
+        exclude(group: "net.java.jinput", module: "jinput")
+        exclude(group: "net.sf.jopt-simple", module: "jopt-simple")
+        exclude(group: "org.ow2.asm", module: "asm-debug-all")
+    }
+    include "com.gitlab.CDAGaming:fabritone:fabric~1.16.3-SNAPSHOT"
 }
 
 processResources {

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
@@ -37,7 +37,10 @@ import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
+import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -74,11 +77,13 @@ public class CrystalAura extends Module {
     private final Setting<Boolean> predictMovement = register(new BooleanSetting("Predict Movement", true));
     private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anit Surround", true));
     private final Setting<Rotations> rotateMode = register(new EnumSetting<>("Rotations", Rotations.PACKET));
+    private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Canceller", Canceller.NO_DESYNC));
 
     enum Mode { DAMAGE, DISTANCE }
     enum Order { PLACE_BREAK, BREAK_PLACE }
     enum Target { CLOSEST, MOST_DAMAGE }
-    enum Rotations { PACKET, REAL }
+    enum Rotations { PACKET, REAL, NONE }
+    enum Canceller { NO_DESYNC, ON_HIT, SOUND_PACKET }
 
     private long renderTimer = -1;
     private long placeTimer = -1;
@@ -247,6 +252,23 @@ public class CrystalAura extends Module {
         }
     });
 
+    //Cancel Crystals if on SOUND_PACKET
+    @EventHandler
+    private EventListener<PacketEvent.Receive> packetReceiveListener = new EventListener<>(event -> {
+        if (event.getPacket() instanceof PlaySoundS2CPacket && cancelMode.getValue() == Canceller.SOUND_PACKET) {
+            final PlaySoundS2CPacket packet = (PlaySoundS2CPacket) event.getPacket();
+            if (packet.getCategory() == SoundCategory.BLOCKS && packet.getSound() == SoundEvents.ENTITY_GENERIC_EXPLODE) {
+                for (Entity e : MC.world.getEntities()) {
+                    if (e instanceof EndCrystalEntity) {
+                        if (e.squaredDistanceTo(packet.getX(), packet.getY(), packet.getZ()) <= 6.0f) {
+                            MC.world.removeEntity(e.getEntityId());
+                        }
+                    }
+                }
+            }
+        }
+    });
+
     // draw target
     @Override
     public void onRender3d() {
@@ -294,6 +316,9 @@ public class CrystalAura extends Module {
 
         //spoof rotations
         rotations = WorldUtils.calculateLookAt(crystal.getX() + 0.5, crystal.getY() + 0.5, crystal.getZ() + 0.5, MC.player);
+
+        //cancel crystal if ON_HIT
+        if(cancelMode.getValue() == Canceller.ON_HIT) MC.world.removeEntity(crystal.getEntityId());
 
         // reset timer
         breakTimer = System.nanoTime() / 1000000;


### PR DESCRIPTION
…ved with default set as "NO_DESYNC" meaning turned off. Also fixed fabric not building by using 1.16.3 branch of fabritone; however, this breaks compatibility with Sodium. The mods will still function together, but Sodium will lock the user in place if they try to use baritone.

**Fixes #.**
Fixed Fabric not building because Fabritone branch was deleted; however, this breaks compatibility with Sodium. The mods will still function together, but Sodium will lock the user in place if they try to use baritone.

**Changes proposed in this pull request:**
Clear explanation of what this fixes or adds
Added crystal cancel (fast mode) options for Crystal Aura on both Fabric and Forge for everyone who kept asking for it to be faster. This has the option to cancel the crystal as soon as the player hits it, or when the server sends the sound packet to the player. By default the setting is set to "NO_DESYNC" as crystal cancel can cause desync.
Added "NONE" to Crystal Aura rotations because some servers don't check for rotations anyways and the PACKET rotations on Fabric triggers the survival fly check on some anticheats. This doesn't appear to happen on the forge version with ViaForge, but I'm not the best person to test it on the particular server in question (endcrystal.me) because my ping is high.

**Additional context**
I would recommend fixing the Fabritone branch as soon as is possible, this is just a band-aid so that it's buildable.