### PR TITLE
Added More CA checks

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
@@ -373,20 +373,26 @@ public class CrystalAura extends Module {
         List<PlayerEntity> targets = new ArrayList<>();
 
         if(targetSetting.getValue() == Target.CLOSEST) {
-            targets.addAll(MC.world.getPlayers().stream().filter(entityPlayer -> !FriendManager.isFriend(entityPlayer.getGameProfile().getName()) && entityPlayer != MC.player).collect(Collectors.toList()));
+            targets.addAll(MC.world.getPlayers().stream().filter(this::isValidTarget).collect(Collectors.toList()));
             targets.sort(Comparators.entityDistance);
         } else if(targetSetting.getValue() == Target.MOST_DAMAGE) {
             for(PlayerEntity entityPlayer: MC.world.getPlayers()) {
-                if(FriendManager.isFriend(entityPlayer.getGameProfile().getName())
-                        || entityPlayer.getHealth() == 0
-                        || MC.player.distanceTo(entityPlayer) > Math.max(placeRange.getValue(), breakRange.getValue()) + 8
-                        || entityPlayer == MC.player)
+                if(!isValidTarget(entityPlayer))
                     continue;
                 targets.add(entityPlayer);
             }
         }
 
         return targets;
+    }
+
+    private boolean isValidTarget(PlayerEntity player) {
+
+        return !FriendManager.isFriend(player.getGameProfile().getName())
+                && !player.isDead()
+                && !(player.getHealth() <= 0)
+                && !(MC.player.distanceTo(player) > Math.max(placeRange.getValue(), breakRange.getValue()) + 8)
+                && player != MC.player;
     }
 
     private List<BlockPos> getPlaceableBlocks(PlayerEntity player) {

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/CrystalAura.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/CrystalAura.java
@@ -370,20 +370,26 @@ public class CrystalAura extends Module {
         List<EntityPlayer> targets = new ArrayList<>();
 
         if(targetSetting.getValue() == Target.CLOSEST) {
-            targets.addAll(MC.world.playerEntities.stream().filter(entityPlayer -> !FriendManager.isFriend(entityPlayer.getGameProfile().getName()) && entityPlayer != MC.player).collect(Collectors.toList()));
+            targets.addAll(MC.world.playerEntities.stream().filter(this::isValidTarget).collect(Collectors.toList()));
             targets.sort(Comparators.entityDistance);
         } else if(targetSetting.getValue() == Target.MOST_DAMAGE) {
             for(EntityPlayer entityPlayer: MC.world.playerEntities) {
-                if(FriendManager.isFriend(entityPlayer.getGameProfile().getName())
-                        || entityPlayer.getHealth() == 0
-                        || MC.player.getDistance(entityPlayer) > Math.max(placeRange.getValue(), breakRange.getValue()) + 8
-                        || entityPlayer == MC.player)
+                if (!isValidTarget(entityPlayer))
                     continue;
                 targets.add(entityPlayer);
             }
         }
 
         return targets;
+    }
+
+    private boolean isValidTarget(EntityPlayer player) {
+
+        return !FriendManager.isFriend(player.getGameProfile().getName())
+                && !player.isDead
+                && !(player.getHealth() <= 0)
+                && !(MC.player.getDistance(player) > Math.max(placeRange.getValue(), breakRange.getValue()) + 8)
+                && player != MC.player;
     }
 
     private List<BlockPos> getPlaceableBlocks(EntityPlayer player) {


### PR DESCRIPTION
**Fixes #.**
Issue #17 

**Changes proposed in this pull request:**

- The "Closest" target setting now filters the same things as "Most Damage".
- Accounts for dead players / players with <= 0 health

**Additional context**
Tested in game for forge and filtering seems to work as expected. 