### PR TITLE
Added Burrow, fixed a typo, made AutoSurround not snap when player is…

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -51,6 +51,7 @@ public class AresMod extends Ares {
                 AutoTotem.class,
                 AutoTrap.class,
                 BowRelease.class,
+                Burrow.class,
                 BurrowDetect.class,
                 Criticals.class,
                 CrystalAura.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoSurround.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoSurround.java
@@ -33,5 +33,6 @@ public class AutoSurround extends Module {
     public void onTick() {
         if(WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE && !Surround.INSTANCE.getEnabled() && hole.getValue())
             Surround.INSTANCE.setEnabled(true);
+            Surround.toggleCenter(false);
     }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Burrow.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Burrow.java
@@ -1,0 +1,199 @@
+package dev.tigr.ares.fabric.impl.modules.combat;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.*;
+import dev.tigr.ares.core.setting.settings.numerical.*;
+import dev.tigr.ares.core.util.global.ReflectionHelper;
+import dev.tigr.ares.core.util.render.TextColor;
+import dev.tigr.ares.fabric.utils.HoleType;
+import dev.tigr.ares.fabric.utils.InventoryUtils;
+import dev.tigr.ares.fabric.utils.WorldUtils;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderTickCounter;
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * @author Makrennel
+ * Built in Timer for FastMode TPS adapted from Timer Module
+ */
+@Module.Info(name = "Burrow", description = "Places a block inside your feet", category = Category.COMBAT)
+public class Burrow extends Module {
+
+    private final Setting<Double> height = register(new DoubleSetting("Height", 1.12, 1.0, 1.3));
+    private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", true));
+    private final Setting<Boolean> autoReturn = register(new BooleanSetting("Auto Switch Return", true));
+    private final Setting<Boolean> holeOnly = register(new BooleanSetting("Hole Only", true));
+    private final Setting<Boolean> toggleSurround = register(new BooleanSetting("Toggle Surround On", false));
+    private final Setting<FastMode> fastMode = register(new EnumSetting<>("Fast Mode", FastMode.NONE));
+    private final Setting<Integer> timerModeTPS = register(new IntegerSetting("FastMode-TPS", 2500, 1, 30000));
+    private final Setting<CurrBlock> blockToUse = register(new EnumSetting<>("Block", CurrBlock.OBSIDIAN));
+    private final Setting<HoleBlock> holeBlock = register(new EnumSetting<>("In Hole", HoleBlock.OBSIDIAN));
+    private final Setting<BackBlock> backupBlock = register(new EnumSetting<>("Backup", BackBlock.ENDER_CHEST));
+
+    enum FastMode {NONE, TPS}
+    enum CurrBlock {OBSIDIAN, ENDER_CHEST, CRYING_OBSIDIAN, NETHERITE_BLOCK, ANCIENT_DEBRIS, ENCHANTING_TABLE, ANVIL}
+    enum HoleBlock {OBSIDIAN, ENDER_CHEST, CRYING_OBSIDIAN, NETHERITE_BLOCK, ANCIENT_DEBRIS, ENCHANTING_TABLE, ANVIL}
+    enum BackBlock {OBSIDIAN, ENDER_CHEST, CRYING_OBSIDIAN, NETHERITE_BLOCK, ANCIENT_DEBRIS, ENCHANTING_TABLE, ANVIL}
+
+    private BlockPos playerPos;
+    private BlockPos airAbove;
+
+    private double jumpHeight;
+
+    float oldYaw;
+    float oldPitch;
+
+    //get the Block value of all three options selected
+    private Block getCurrBlock(){
+        Block current = null;
+        if (blockToUse.getValue() == CurrBlock.OBSIDIAN) {current = Blocks.OBSIDIAN;}
+        else if (blockToUse.getValue() == CurrBlock.ENDER_CHEST) {current = Blocks.ENDER_CHEST;}
+        else if (blockToUse.getValue() == CurrBlock.CRYING_OBSIDIAN) {current = Blocks.CRYING_OBSIDIAN;}
+        else if (blockToUse.getValue() == CurrBlock.NETHERITE_BLOCK) {current = Blocks.NETHERITE_BLOCK;}
+        else if (blockToUse.getValue() == CurrBlock.ANCIENT_DEBRIS) {current = Blocks.ANCIENT_DEBRIS;}
+        else if (blockToUse.getValue() == CurrBlock.ENCHANTING_TABLE) {current = Blocks.ENCHANTING_TABLE;}
+        else if (blockToUse.getValue() == CurrBlock.ANVIL) {current = Blocks.ANVIL;}
+        return current;
+    }
+    private Block getHoleBlock(){
+        Block hole = null;
+        if (holeBlock.getValue() == HoleBlock.OBSIDIAN) {hole = Blocks.OBSIDIAN;}
+        else if (holeBlock.getValue() == HoleBlock.ENDER_CHEST) {hole = Blocks.ENDER_CHEST;}
+        else if (holeBlock.getValue() == HoleBlock.CRYING_OBSIDIAN) {hole = Blocks.CRYING_OBSIDIAN;}
+        else if (holeBlock.getValue() == HoleBlock.NETHERITE_BLOCK) {hole = Blocks.NETHERITE_BLOCK;}
+        else if (holeBlock.getValue() == HoleBlock.ANCIENT_DEBRIS) {hole = Blocks.ANCIENT_DEBRIS;}
+        else if (holeBlock.getValue() == HoleBlock.ENCHANTING_TABLE) {hole = Blocks.ENCHANTING_TABLE;}
+        else if (holeBlock.getValue() == HoleBlock.ANVIL) {hole = Blocks.ANVIL;}
+        return hole;
+    }
+    private Block getBackBlock(){
+        Block backup = null;
+        if (backupBlock.getValue() == BackBlock.OBSIDIAN) {backup = Blocks.OBSIDIAN;}
+        else if (backupBlock.getValue() == BackBlock.ENDER_CHEST) {backup = Blocks.ENDER_CHEST;}
+        else if (backupBlock.getValue() == BackBlock.CRYING_OBSIDIAN) {backup = Blocks.CRYING_OBSIDIAN;}
+        else if (backupBlock.getValue() == BackBlock.NETHERITE_BLOCK) {backup = Blocks.NETHERITE_BLOCK;}
+        else if (backupBlock.getValue() == BackBlock.ANCIENT_DEBRIS) {backup = Blocks.ANCIENT_DEBRIS;}
+        else if (backupBlock.getValue() == BackBlock.ENCHANTING_TABLE) {backup = Blocks.ENCHANTING_TABLE;}
+        else if (backupBlock.getValue() == BackBlock.ANVIL) {backup = Blocks.ANVIL;}
+        return backup;
+    }
+
+    @Override
+    public void onEnable() {
+        playerPos = new BlockPos(MC.player.getX(), MC.player.getY(), MC.player.getZ());
+        double airAboveY = playerPos.getY() + 3;
+        airAbove = new BlockPos(playerPos.getX(), airAboveY, playerPos.getZ());
+        double eTableHeight = height.getValue() - 0.25;
+
+        //determine if player is already burrowed
+        if (MC.world.getBlockState(playerPos).getBlock() == getCurrBlock() || MC.world.getBlockState(playerPos).getBlock() == getBackBlock() || MC.world.getBlockState(playerPos).getBlock() == getHoleBlock() || MC.world.getBlockState(playerPos).getBlock() == Blocks.ENCHANTING_TABLE) {
+            UTILS.printMessage(TextColor.BLUE + "Already Burrowed!");
+            setEnabled(false);
+            return;
+        }
+
+        //toggles off if player is not in hole and set to hole only
+        if (WorldUtils.isHole(MC.player.getBlockPos()) == HoleType.NONE && holeOnly.getValue()) {
+            UTILS.printMessage(TextColor.RED + "Not in a hole!");
+            setEnabled(false);
+            return;
+        }
+
+        //checks there is enough space above player, and automatically changes height if not so enchanting table can be used if in hotbar.
+        if (MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
+            if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) > 0) {
+                jumpHeight = eTableHeight;
+            }
+            else if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) {
+                UTILS.printMessage(TextColor.RED + "Not enough space above!");
+                setEnabled(false);
+                return;
+            }
+        }
+        else jumpHeight = height.getValue();
+
+        //checks that player has the blocks needed available
+        if (InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0 && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0 || InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0 && WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0){
+            UTILS.printMessage(TextColor.RED + "No Burrow Blocks Found!");
+            setEnabled(false);
+            return;
+        }
+
+        //toggles Surround with snap turned off (snap breaks burrow)
+        if(toggleSurround.getValue()) {
+            Surround.INSTANCE.setEnabled(true);
+            Surround.toggleCenter(false);
+        }
+
+        //turns on Timer if Fast Mode is set to TPS
+        if (fastMode.getValue() == FastMode.TPS) {
+            ReflectionHelper.setPrivateValue(RenderTickCounter.class, ReflectionHelper.getPrivateValue(MinecraftClient.class, MC, "renderTickCounter", "field_1728"), 1000.0F / timerModeTPS.getValue(), "tickTime", "field_1968");
+        }
+
+        //jump
+        MC.player.jump();
+    }
+    public void onTick() {
+        //run the main sequence
+        run();
+    }
+    public void onDisable() {
+        //turns off Timer
+        if(fastMode.getValue() == FastMode.TPS) {
+            ReflectionHelper.setPrivateValue(RenderTickCounter.class, ReflectionHelper.getPrivateValue(MinecraftClient.class, MC, "renderTickCounter", "field_1728"), 1000.0F / 20.0F, "tickTime", "field_1968");
+        }
+        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(oldYaw, oldPitch, MC.player.isOnGround()));
+    }
+    public void run() {
+        if (MC.player == null || MC.world == null) return;
+
+        int oldSelection = -1;
+        oldYaw = MC.player.yaw;
+        oldPitch = MC.player.pitch;
+
+        if (MC.player.getY() >= playerPos.getY() + jumpHeight) {
+            //main block to use
+            if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) && MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
+                oldSelection = MC.player.inventory.selectedSlot;
+                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(Blocks.ENCHANTING_TABLE);
+            }
+
+            //block when in hole
+            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0) && WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE) {
+                oldSelection = MC.player.inventory.selectedSlot;
+                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getHoleBlock());
+            }
+
+            //main block
+            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0)) {
+                oldSelection = MC.player.inventory.selectedSlot;
+                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getCurrBlock());
+            }
+
+            //backup block to use when either is unavailable
+            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0)) {
+                oldSelection = MC.player.inventory.selectedSlot;
+                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getBackBlock());
+            }
+
+            //place block where the player was before jumping
+            WorldUtils.placeBlockMainHand(playerPos);
+
+            //switches back to initial item held if both Auto Switch and Auto Switch Return are true
+            if (autoSwitch.getValue() && autoReturn.getValue()) {
+                MC.player.inventory.selectedSlot = oldSelection;
+            }
+
+            //jumps again to snap player down
+            MC.player.jump();
+
+            //disable module
+            setEnabled(false);
+        }
+    }
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
@@ -75,7 +75,7 @@ public class CrystalAura extends Module {
     private final Setting<Integer> maxBreakTries = register(new IntegerSetting("Break Attempts", 2, 1, 5));
     private final Setting<Boolean> sync = register(new BooleanSetting("Sync", true));
     private final Setting<Boolean> predictMovement = register(new BooleanSetting("Predict Movement", true));
-    private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anit Surround", true));
+    private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anti-Surround", true));
     private final Setting<Rotations> rotateMode = register(new EnumSetting<>("Rotations", Rotations.PACKET));
     private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Canceller", Canceller.NO_DESYNC));
 

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Surround.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Surround.java
@@ -31,6 +31,10 @@ public class Surround extends Module {
         INSTANCE = this;
     }
 
+    // this is to allow turning off Center when toggling surround from another module without the player having to disable Center in Surround itself
+    boolean doSnap = true;
+    public static void toggleCenter(boolean doSnap) {}
+
     @Override
     public void onTick() {
         if(!MC.player.isOnGround()) return;
@@ -98,7 +102,7 @@ public class Surround extends Module {
     public void onEnable() {
         lastPos = MC.player.getBlockPos();
 
-        if(snap.getValue()) {
+        if(snap.getValue() && doSnap == true) {
             double xPos = MC.player.getPos().x;
             double zPos = MC.player.getPos().z;
 

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/InventoryUtils.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/InventoryUtils.java
@@ -23,6 +23,20 @@ public class InventoryUtils implements Wrapper {
         return quantity;
     }
 
+    public static int amountInHotbar(Item item) {
+        int quantity = 0;
+
+        for(int i = 0; i <= 9; i++) {
+            ItemStack stackInSlot = MC.player.inventory.getStack(i);
+            if(stackInSlot.getItem() == item) quantity += stackInSlot.getCount();
+        }
+        if(MC.player.getOffHandStack().getItem() == item) quantity += MC.player.getOffHandStack().getCount();
+
+        return quantity;
+    }
+
+    public static int amountBlockInHotbar(Block block) {return amountInHotbar(new ItemStack(block).getItem());}
+
     public static int findItem(Item item) {
         int index = -1;
         for(int i = 0; i < 45; i++) {

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
@@ -67,6 +67,7 @@ public class AresMod extends Ares {
                 AutoTotem.class,
                 AutoTrap.class,
                 BowRelease.class,
+                Burrow.class,
                 BurrowDetect.class,
                 Criticals.class,
                 CrystalAura.class,

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoSurround.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoSurround.java
@@ -32,5 +32,6 @@ public class AutoSurround extends Module {
     public void onTick() {
         if(WorldUtils.isHole(MC.player.getPosition()) != HoleType.NONE && !Surround.INSTANCE.getEnabled() && hole.getValue())
             Surround.INSTANCE.setEnabled(true);
+            Surround.toggleCenter(false);
     }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Burrow.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Burrow.java
@@ -1,0 +1,188 @@
+package dev.tigr.ares.forge.impl.modules.combat;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.*;
+import dev.tigr.ares.core.setting.settings.numerical.*;
+import dev.tigr.ares.core.util.global.ReflectionHelper;
+import dev.tigr.ares.core.util.render.TextColor;
+import dev.tigr.ares.forge.utils.HoleType;
+import dev.tigr.ares.forge.utils.InventoryUtils;
+import dev.tigr.ares.forge.utils.WorldUtils;
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.init.Blocks;
+import net.minecraft.network.play.client.CPacketPlayer;
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * @author Makrennel
+ * Built in Timer for FastMode TPS adapted from Timer Module
+ */
+@Module.Info(name = "Burrow", description = "Places an obsidian block inside your feet", category = Category.COMBAT)
+public class Burrow extends Module {
+
+    private final Setting<Double> height = register(new DoubleSetting("Height", 1.12, 1.0, 1.3));
+    private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", true));
+    private final Setting<Boolean> autoReturn = register(new BooleanSetting("Auto Switch Return", true));
+    private final Setting<Boolean> holeOnly = register(new BooleanSetting("Hole Only", true));
+    private final Setting<Boolean> toggleSurround = register(new BooleanSetting("Toggle Surround On", false));
+    private final Setting<FastMode> fastMode = register(new EnumSetting<>("Fast Mode", FastMode.NONE));
+    private final Setting<Integer> timerModeTPS = register(new IntegerSetting("FastMode-TPS", 2500, 1, 30000));
+    private final Setting<CurrBlock> blockToUse = register(new EnumSetting<>("Block", CurrBlock.OBSIDIAN));
+    private final Setting<HoleBlock> holeBlock = register(new EnumSetting<>("In Hole", HoleBlock.OBSIDIAN));
+    private final Setting<BackBlock> backupBlock = register(new EnumSetting<>("Backup", BackBlock.ENDER_CHEST));
+
+    enum FastMode {NONE, TPS}
+    enum CurrBlock {OBSIDIAN, ENDER_CHEST, ENCHANTING_TABLE, ANVIL}
+    enum HoleBlock {OBSIDIAN, ENDER_CHEST, ENCHANTING_TABLE, ANVIL}
+    enum BackBlock {OBSIDIAN, ENDER_CHEST, ENCHANTING_TABLE, ANVIL}
+
+    private BlockPos playerPos;
+    private BlockPos airAbove;
+
+    private double jumpHeight;
+
+    float oldYaw;
+    float oldPitch;
+
+    //get the Block value of all three options selected
+    private Block getCurrBlock(){
+        Block current = null;
+        if (blockToUse.getValue() == CurrBlock.OBSIDIAN) {current = Blocks.OBSIDIAN;}
+        else if (blockToUse.getValue() == CurrBlock.ENDER_CHEST) {current = Blocks.ENDER_CHEST;}
+        else if (blockToUse.getValue() == CurrBlock.ENCHANTING_TABLE) {current = Blocks.ENCHANTING_TABLE;}
+        else if (blockToUse.getValue() == CurrBlock.ANVIL) {current = Blocks.ANVIL;}
+        return current;
+    }
+    private Block getHoleBlock(){
+        Block hole = null;
+        if (holeBlock.getValue() == HoleBlock.OBSIDIAN) {hole = Blocks.OBSIDIAN;}
+        else if (holeBlock.getValue() == HoleBlock.ENDER_CHEST) {hole = Blocks.ENDER_CHEST;}
+        else if (holeBlock.getValue() == HoleBlock.ENCHANTING_TABLE) {hole = Blocks.ENCHANTING_TABLE;}
+        else if (holeBlock.getValue() == HoleBlock.ANVIL) {hole = Blocks.ANVIL;}
+        return hole;
+    }
+    private Block getBackBlock(){
+        Block backup = null;
+        if (backupBlock.getValue() == BackBlock.OBSIDIAN) {backup = Blocks.OBSIDIAN;}
+        else if (backupBlock.getValue() == BackBlock.ENDER_CHEST) {backup = Blocks.ENDER_CHEST;}
+        else if (backupBlock.getValue() == BackBlock.ENCHANTING_TABLE) {backup = Blocks.ENCHANTING_TABLE;}
+        else if (backupBlock.getValue() == BackBlock.ANVIL) {backup = Blocks.ANVIL;}
+        return backup;
+    }
+
+    @Override
+    public void onEnable() {
+        playerPos = new BlockPos(MC.player.posX, MC.player.posY, MC.player.posZ);
+        double airAboveY = playerPos.getY() + 3;
+        airAbove = new BlockPos(playerPos.getX(), airAboveY, playerPos.getZ());
+        double eTableHeight = height.getValue() - 0.25;
+
+        //determine if player is already burrowed
+        if (MC.world.getBlockState(playerPos).getBlock() == getCurrBlock() || MC.world.getBlockState(playerPos).getBlock() == getBackBlock() || MC.world.getBlockState(playerPos).getBlock() == getHoleBlock() || MC.world.getBlockState(playerPos).getBlock() == Blocks.ENCHANTING_TABLE) {
+            UTILS.printMessage(TextColor.BLUE + "Already Burrowed!");
+            setEnabled(false);
+            return;
+        }
+
+        //toggles off if player is not in hole and set to hole only
+        if (WorldUtils.isHole(MC.player.getPosition()) == HoleType.NONE && holeOnly.getValue()) {
+            UTILS.printMessage(TextColor.RED + "Not in a hole!");
+            setEnabled(false);
+            return;
+        }
+
+        //checks there is enough space above player, and automatically changes height if not so enchanting table can be used if in hotbar.
+        if (MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
+            if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) > 0) {
+                jumpHeight = eTableHeight;
+            }
+            else if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) {
+                UTILS.printMessage(TextColor.RED + "Not enough space above!");
+                setEnabled(false);
+                return;
+            }
+        }
+        else jumpHeight = height.getValue();
+
+        //checks that player has the blocks needed available
+        if (InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0 && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0 || InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0 && WorldUtils.isHole(MC.player.getPosition()) != HoleType.NONE && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0){
+            UTILS.printMessage(TextColor.RED + "No Burrow Blocks Found!");
+            setEnabled(false);
+            return;
+        }
+
+        //toggles Surround with snap turned off (snap breaks burrow)
+        if(toggleSurround.getValue()) {
+            Surround.INSTANCE.setEnabled(true);
+            Surround.toggleCenter(false);
+        }
+
+        //jump
+        MC.player.jump();
+    }
+    public void onTick() {
+        //turns on Timer if Fast Mode is set to TPS
+        if (fastMode.getValue() == FastMode.TPS) {
+            ReflectionHelper.setPrivateValue(net.minecraft.util.Timer.class, ReflectionHelper.getPrivateValue(Minecraft.class, MC, "timer", "field_71428_T"), 1000.0F / timerModeTPS.getValue(), "tickLength", "field_194149_e");
+        }
+        //run the main sequence
+        run();
+    }
+    public void onDisable() {
+        //turns off Timer
+        if(fastMode.getValue() == FastMode.TPS) {
+            ReflectionHelper.setPrivateValue(net.minecraft.util.Timer.class, ReflectionHelper.getPrivateValue(Minecraft.class, MC, "timer", "field_71428_T"), 1000.0F / 20.0F, "tickLength", "field_194149_e");
+        }
+        MC.player.connection.sendPacket(new CPacketPlayer.Rotation(oldYaw, oldPitch, MC.player.onGround));
+    }
+    public void run() {
+        if (MC.player == null || MC.world == null) return;
+
+        int oldSelection = -1;
+        oldYaw = MC.player.rotationYaw;
+        oldPitch = MC.player.rotationPitch;
+
+        if (MC.player.posY > playerPos.getY() + jumpHeight) {
+            //main block to use
+            if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) && MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
+                oldSelection = MC.player.inventory.currentItem;
+                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(Blocks.ENCHANTING_TABLE);
+            }
+
+            //block when in hole
+            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0) && WorldUtils.isHole(MC.player.getPosition()) != HoleType.NONE) {
+                oldSelection = MC.player.inventory.currentItem;
+                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getHoleBlock());
+            }
+
+            //main block
+            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0)) {
+                oldSelection = MC.player.inventory.currentItem;
+                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getCurrBlock());
+            }
+
+            //backup block to use when either is unavailable
+            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0)) {
+                oldSelection = MC.player.inventory.currentItem;
+                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getBackBlock());
+            }
+
+            //place block where the player was before jumping
+            WorldUtils.placeBlockMainHand(playerPos);
+
+            //switches back to initial item held if both Auto Switch and Auto Switch Return are true
+            if (autoSwitch.getValue() && autoReturn.getValue()) {
+                MC.player.inventory.currentItem = oldSelection;
+            }
+
+            //jumps again to snap down if FastMode is not TPS
+            MC.player.jump();
+
+            //disable module
+            setEnabled(false);
+        }
+    }
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/CrystalAura.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/CrystalAura.java
@@ -69,7 +69,7 @@ public class CrystalAura extends Module {
     private final Setting<Integer> maxBreakTries = register(new IntegerSetting("Break Attempts", 2, 1, 5));
     private final Setting<Boolean> sync = register(new BooleanSetting("Sync", true));
     private final Setting<Boolean> predictMovement = register(new BooleanSetting("Predict Movement", true));
-    private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anit Surround", true));
+    private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anti-Surround", true));
     private final Setting<Rotations> rotateMode = register(new EnumSetting<>("Rotations", Rotations.PACKET));
     private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Canceller", Canceller.NO_DESYNC));
 

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Surround.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Surround.java
@@ -31,6 +31,10 @@ public class Surround extends Module {
         INSTANCE = this;
     }
 
+    // this is to allow turning off Center when toggling surround from another module without the player having to disable Center in Surround itself
+    boolean doSnap = true;
+    public static void toggleCenter(boolean doSnap) {}
+
     @Override
     public void onTick() {
         if(!MC.player.onGround) return;
@@ -93,7 +97,7 @@ public class Surround extends Module {
     public void onEnable() {
         BlockPos pos = lastPos = new BlockPos(MC.player.getPositionVector());
 
-        if(snap.getValue()) {
+        if(snap.getValue() && doSnap == true) {
             double xPos = MC.player.getPositionVector().x;
             double zPos = MC.player.getPositionVector().z;
 

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/utils/InventoryUtils.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/utils/InventoryUtils.java
@@ -23,6 +23,20 @@ public class InventoryUtils {
         return quantity;
     }
 
+    public static int amountInHotbar(Item item) {
+        int quantity = 0;
+
+        for(int i = 44; i > 35; i--) {
+            ItemStack stackInSlot = MC.player.inventoryContainer.getSlot(i).getStack();
+            if(stackInSlot.getItem() == item) quantity += stackInSlot.getCount();
+        }
+        if(MC.player.getHeldItemOffhand().getItem() == item) quantity += MC.player.getHeldItemOffhand().getCount();
+
+        return quantity;
+    }
+
+    public static int amountBlockInHotbar(Block block) {return amountInHotbar(new ItemStack(block).getItem());}
+
     public static int findItem(Item item) {
         int index = -1;
         for(int i = 44; i > -1; i--) {


### PR DESCRIPTION
… entering a hole (particularly on fabric).

**Fixes #.**
Fixes AutoSurround trying to snap when player enters a hole, triggering Anticheats and slowing down entry to hole (this was particularly a problem with the fabric version).

**Changes proposed in this pull request:**
Added Burrow to both fabric and forge with lots of options for flexibility, and a fast mode using a built in timer. Tested on Endcrystal.me (before patch), Pureanarky.org, and 9b9t.org.
Added methods to count number of items/blocks in hotbar based on existing methods in InventoryUtils.
Made it possible to turn off snap if toggling Surround from another class.

**Additional context**
Fixed a typo in CrystalAura in the setting named "Anti-Surround" (previously Anit Surround).