### PR TITLE
Instant Burrow, Instant Mine, (forge) AutoCity fix, AutoCity 1.13+ Mode, FireworkAura, Surround fixes and options, Timer Util, placeBlock options, Rotate toggles, temporary CrystalAura color settings.

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -80,6 +80,7 @@ public class AresMod extends Ares {
 
                 // exploit
                 FastPlace.class,
+                InstantMine.class,
                 LiquidInteract.class,
                 MultiTask.class,
                 NoBreakDelay.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -58,6 +58,7 @@ public class AresMod extends Ares {
                 BurrowDetect.class,
                 Criticals.class,
                 CrystalAura.class,
+                FireworkAura.class,
                 HoleFiller.class,
                 KillAura.class,
                 Offhand.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -112,6 +112,7 @@ public class AresMod extends Ares {
                 IceSpeed.class,
                 InventoryMove.class,
                 Jesus.class,
+                NoBlockPush.class,
                 NoClip.class,
                 NoSlowDown.class,
                 PacketFly.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/movement/BlockPushEvent.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/movement/BlockPushEvent.java
@@ -1,0 +1,17 @@
+package dev.tigr.ares.fabric.event.movement;
+
+import dev.tigr.simpleevents.event.Event;
+
+/**
+ * @author Makrennel
+ */
+public class BlockPushEvent extends Event {
+    public double var1;
+    public double var2;
+
+    public BlockPushEvent(double var1, double var2) {
+        this.setCancelled(false);
+        this.var1 = var1;
+        this.var2 = var2;
+    }
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AnchorAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AnchorAura.java
@@ -123,7 +123,7 @@ public class AnchorAura extends Module {
         }
 
         // place
-        WorldUtils.placeBlockMainHand(pos);
+        WorldUtils.placeBlockMainHand(pos, shouldRotate());
         placed.add(pos);
 
         // set render pos
@@ -297,5 +297,11 @@ public class AnchorAura extends Module {
 
     private boolean canAnchorBePlacedHere(BlockPos pos) {
         return MC.world.getBlockState(pos).isAir();
+    }
+
+    private boolean shouldRotate() {
+        if (rotateMode.getValue() == Rotations.NONE)
+            return false;
+        else return true;
     }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AntiBedAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AntiBedAura.java
@@ -2,6 +2,8 @@ package dev.tigr.ares.fabric.impl.modules.combat;
 
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.fabric.utils.HoleType;
 import dev.tigr.ares.fabric.utils.InventoryUtils;
 import dev.tigr.ares.fabric.utils.WorldUtils;
@@ -14,6 +16,7 @@ import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
  */
 @Module.Info(name = "AntiBedAura", description = "automatically places string in hitbox when in hole to prevent beds", category = Category.COMBAT)
 public class AntiBedAura extends Module {
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     @Override
     public void onTick() {
         if(WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE && MC.world.getBlockState(MC.player.getBlockPos().up()).getBlock() != Block.getBlockFromItem(Items.STRING)) {
@@ -25,7 +28,7 @@ public class AntiBedAura extends Module {
                     MC.player.networkHandler.sendPacket(new UpdateSelectedSlotC2SPacket());
                 }
             }
-            WorldUtils.placeBlockMainHand(MC.player.getBlockPos().up());
+            WorldUtils.placeBlockMainHand(MC.player.getBlockPos().up(), rotate.getValue());
             MC.player.inventory.selectedSlot = prev;
         }
     }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AntiBedAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AntiBedAura.java
@@ -2,6 +2,8 @@ package dev.tigr.ares.fabric.impl.modules.combat;
 
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.fabric.utils.HoleType;
 import dev.tigr.ares.fabric.utils.InventoryUtils;
 import dev.tigr.ares.fabric.utils.WorldUtils;
@@ -14,6 +16,7 @@ import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
  */
 @Module.Info(name = "AntiBedAura", description = "automatically places string in hitbox when in hole to prevent beds", category = Category.COMBAT)
 public class AntiBedAura extends Module {
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     // TODO: remove this or make it work better
     @Override
     public void onTick() {
@@ -26,7 +29,7 @@ public class AntiBedAura extends Module {
                     MC.player.networkHandler.sendPacket(new UpdateSelectedSlotC2SPacket());
                 }
             }
-            WorldUtils.placeBlockMainHand(MC.player.getBlockPos().up());
+            WorldUtils.placeBlockMainHand(MC.player.getBlockPos().up(), rotate.getValue());
             MC.player.inventory.selectedSlot = prev;
         }
     }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoCity.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoCity.java
@@ -4,6 +4,7 @@ import dev.tigr.ares.core.feature.FriendManager;
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
 import dev.tigr.ares.core.util.render.TextColor;
 import dev.tigr.ares.fabric.utils.Comparators;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 @Module.Info(name = "AutoCity", description = "Automatically mines closest players surround", category = Category.COMBAT)
 public class AutoCity extends Module {
     private final Setting<Double> range = register(new DoubleSetting("Range", 5, 0, 10));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     
     @Override
     public void onEnable() {
@@ -64,8 +66,10 @@ public class AutoCity extends Module {
                     MC.player.networkHandler.sendPacket(new UpdateSelectedSlotC2SPacket(index));
 
                     // rotate
-                    double[] rotations = WorldUtils.calculateLookAt(target.getX() + 0.5, target.getY() + 0.5, target.getZ() + 0.5, MC.player);
-                    MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly((float) rotations[0], (float) rotations[1], MC.player.isOnGround()));
+                    if (rotate.getValue()) {
+                        double[] rotations = WorldUtils.calculateLookAt(target.getX() + 0.5, target.getY() + 0.5, target.getZ() + 0.5, MC.player);
+                        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly((float) rotations[0], (float) rotations[1], MC.player.isOnGround()));
+                    }
 
                     // break
                     MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, target, Direction.UP));

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoCity.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoCity.java
@@ -32,6 +32,7 @@ public class AutoCity extends Module {
     private final Setting<Double> range = register(new DoubleSetting("Range", 5, 0, 10));
     private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Boolean> instant = register(new BooleanSetting("Instant", true));
+    private final Setting<Boolean> oneDotThirteen = register(new BooleanSetting("1.13+", true));
 
     private boolean toggleInstant = false;
 
@@ -54,8 +55,10 @@ public class AutoCity extends Module {
                 BlockPos target = null;
                 for(BlockPos block: blocks) {
                     if(!inPlayerCity(block) && MC.world.getBlockState(block).getBlock() != Blocks.BEDROCK && MC.player.squaredDistanceTo(block.getX() + 0.5, block.getY() + 0.5, block.getZ() + 0.5) < range.getValue() * range.getValue()) {
-                        target = block;
-                        break;
+                        if (oneDotThirteen.getValue() || MC.world.getBlockState(new BlockPos(block.getX(), block.getY() + 1, block.getZ())).getBlock() == Blocks.AIR) {
+                            target = block;
+                            break;
+                        }
                     }
                 }
                 if(target == null) continue;

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoSurround.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoSurround.java
@@ -4,6 +4,7 @@ import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
 import dev.tigr.ares.core.setting.settings.BooleanSetting;
+import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
 import dev.tigr.ares.fabric.event.client.PacketEvent;
 import dev.tigr.ares.fabric.utils.HoleType;
 import dev.tigr.ares.fabric.utils.WorldUtils;
@@ -18,21 +19,28 @@ import net.minecraft.network.packet.s2c.play.EntityStatusS2CPacket;
 @Module.Info(name = "AutoSurround", description = "Automatically enable surround in certain circumstances", category = Category.COMBAT)
 public class AutoSurround extends Module {
     private final Setting<Boolean> hole = register(new BooleanSetting("When in hole", true));
+    private final Setting<Boolean> holeSnap = register(new BooleanSetting("Hole Center", false)) .setVisibility(hole::getValue);
+    private final Setting<Integer> holeDelay = register(new IntegerSetting("Time Before", 250, 0, 1000)).setVisibility(hole::getValue);
     private final Setting<Boolean> pop = register(new BooleanSetting("On totem pop", false));
+    private final Setting<Boolean> popSnap = register(new BooleanSetting("Totem Center", true)).setVisibility(pop::getValue);
+
     @EventHandler
     public EventListener<PacketEvent.Receive> packetReceiveEvent = new EventListener<>(event -> {
         if(MC.player != null && event.getPacket() instanceof EntityStatusS2CPacket && pop.getValue()) {
             EntityStatusS2CPacket status = (EntityStatusS2CPacket) event.getPacket();
             if(status.getStatus() == 35 && status.getEntity(MC.world) == MC.player) {
                 Surround.INSTANCE.setEnabled(true);
+                Surround.toggleCenter(popSnap.getValue());
             }
         }
     });
 
     @Override
     public void onTick() {
-        if(WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE && !Surround.INSTANCE.getEnabled() && hole.getValue())
+        if (WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE && !Surround.INSTANCE.getEnabled() && hole.getValue()) {
             Surround.INSTANCE.setEnabled(true);
-            Surround.toggleCenter(false);
+            Surround.toggleCenter(holeSnap.getValue());
+            Surround.setSurroundWait(holeDelay.getValue());
+        }
     }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoSurround.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoSurround.java
@@ -20,7 +20,7 @@ import net.minecraft.network.packet.s2c.play.EntityStatusS2CPacket;
 public class AutoSurround extends Module {
     private final Setting<Boolean> hole = register(new BooleanSetting("When in hole", true));
     private final Setting<Boolean> holeSnap = register(new BooleanSetting("Hole Center", false)) .setVisibility(hole::getValue);
-    private final Setting<Integer> holeDelay = register(new IntegerSetting("Time Before", 250, 0, 1000)).setVisibility(hole::getValue);
+    private final Setting<Integer> holeDelay = register(new IntegerSetting("Hole D.(ms)", 250, 0, 1000)).setVisibility(hole::getValue);
     private final Setting<Boolean> pop = register(new BooleanSetting("On totem pop", false));
     private final Setting<Boolean> popSnap = register(new BooleanSetting("Totem Center", true)).setVisibility(pop::getValue);
 

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoTrap.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoTrap.java
@@ -47,7 +47,7 @@ public class AutoTrap extends Module {
                             ) {
                                 //place block
                                 int oldSlot = MC.player.inventory.selectedSlot;
-                                int newSlot = InventoryUtils.findBlock(Blocks.OBSIDIAN);
+                                int newSlot = InventoryUtils.findBlockInHotbar(Blocks.OBSIDIAN);
                                 if (newSlot == -1) return;
                                 else MC.player.inventory.selectedSlot = newSlot;
                                 WorldUtils.placeBlockMainHand(pos, rotate.getValue());

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoTrap.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoTrap.java
@@ -21,12 +21,10 @@ import net.minecraft.util.math.Box;
  */
 @Module.Info(name = "AutoTrap", description = "Automatically trap people in holes", category = Category.COMBAT)
 public class AutoTrap extends Module {
-    private final Setting<Mode> mode = register(new EnumSetting<>("Mode", Mode.Full));
+    private final Setting<Mode> mode = register(new EnumSetting<>("Mode", Mode.FULL));
     private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Double> range = register(new DoubleSetting("Range", 8.0D, 0.0D, 15.0D));
-    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 100, 0, 500));
-
-    enum Mode { Full, CrystalAir, CrystalFull, TopOnly, TopOnly3x3 }
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay(ms)", 100, 0, 500));
 
     private final Timer delayTimer = new Timer();
 
@@ -66,7 +64,7 @@ public class AutoTrap extends Module {
         BlockPos playerPos = new BlockPos(player.getPos());
         BlockPos[] blocks;
 
-        if(mode.getValue() == Mode.Full) {
+        if(mode.getValue() == Mode.FULL) {
             blocks = new BlockPos[]{
                     playerPos.add(1, -1, 0),
                     playerPos.add(1, 0, 0),
@@ -87,7 +85,7 @@ public class AutoTrap extends Module {
                     playerPos.add(1, 2, 0),
                     playerPos.add(0, 2, 0)
             };
-        } else if (mode.getValue() == Mode.CrystalAir) {
+        } else if (mode.getValue() == Mode.CRYSTALAIR) {
             blocks = new BlockPos[]{
                     playerPos.add(0, 1, 1),
                     playerPos.add(0, 1, -1),
@@ -97,11 +95,37 @@ public class AutoTrap extends Module {
                     playerPos.add(1, 2, 0),
                     playerPos.add(0, 2, 0)
             };
-        } else if(mode.getValue() == Mode.TopOnly) {
+        } else if(mode.getValue() == Mode.CRYSTALTOP) {
+            blocks = new BlockPos[]{
+                    playerPos.add(1, -1, 0),
+                    playerPos.add(1, 0, 0),
+                    playerPos.add(1, 1, 0),
+                    playerPos.add(1, 2, 0),
+
+                    playerPos.add(0, 2, 0),
+                    playerPos.add(-1, 2, 0),
+                    playerPos.add(0, 2, 1),
+                    playerPos.add(0, 2, -1),
+
+                    playerPos.add(-1, 1, 0),
+                    playerPos.add(0, 1, 1),
+                    playerPos.add(0, 1, -1),
+
+            };
+        } else if(mode.getValue() == Mode.TOPONLY) {
+            blocks = new BlockPos[]{
+                    playerPos.add(1, -1, 0),
+                    playerPos.add(1, 0, 0),
+                    playerPos.add(1, 1, 0),
+                    playerPos.add(1, 2, 0),
+
+                    playerPos.add(0, 2, 0)
+            };
+        } else if(mode.getValue() == Mode.TOPAIR) {
             blocks = new BlockPos[]{
                     playerPos.add(0, 2, 0)
             };
-        } else if (mode.getValue() == Mode.TopOnly3x3) {
+        } else if (mode.getValue() == Mode.TOP3x3) {
             blocks = new BlockPos[]{
                     playerPos.add(0, 2, 0),
 
@@ -145,4 +169,7 @@ public class AutoTrap extends Module {
 
         return blocks;
     }
+
+
+    enum Mode { FULL, CRYSTALAIR, CRYSTALTOP, CRYSTALFULL, TOPONLY, TOPAIR, TOP3x3 }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoTrap.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/AutoTrap.java
@@ -4,10 +4,12 @@ import dev.tigr.ares.core.feature.FriendManager;
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.EnumSetting;
 import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
 import dev.tigr.ares.fabric.utils.InventoryUtils;
+import dev.tigr.ares.fabric.utils.Timer;
 import dev.tigr.ares.fabric.utils.WorldUtils;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.player.PlayerEntity;
@@ -19,34 +21,40 @@ import net.minecraft.util.math.Box;
  */
 @Module.Info(name = "AutoTrap", description = "Automatically trap people in holes", category = Category.COMBAT)
 public class AutoTrap extends Module {
-    private final Setting<Mode> mode = register(new EnumSetting<>("Mode", Mode.FULL));
+    private final Setting<Mode> mode = register(new EnumSetting<>("Mode", Mode.Full));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Double> range = register(new DoubleSetting("Range", 8.0D, 0.0D, 15.0D));
-    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 2, 0, 10));
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 100, 0, 500));
+
+    enum Mode { Full, CrystalAir, CrystalFull, TopOnly, TopOnly3x3 }
+
+    private final Timer delayTimer = new Timer();
 
     @Override
     public void onTick() {
-        if(TICKS % delay.getValue() != 0) return;
+        if (delayTimer.passedMillis(delay.getValue())) {
+            for (PlayerEntity player : MC.world.getPlayers()) {
+                if (FriendManager.isFriend(player.getGameProfile().getName()) || MC.player == player) continue;
 
-        for(PlayerEntity player: MC.world.getPlayers()) {
-            if(FriendManager.isFriend(player.getGameProfile().getName()) || MC.player == player) continue;
-
-            if(MC.player.distanceTo(player) <= range.getValue()) {
-                for(BlockPos pos: getPos(player)) {
-                    if(MC.world.getBlockState(pos).getMaterial().isReplaceable()) {
-                        if(
-                                MC.world.getOtherEntities(
-                                        null,
-                                        new Box(pos)
-                                ).isEmpty()
-                        ) {
-                            //place block
-                            int oldSlot = MC.player.inventory.selectedSlot;
-                            int newSlot = InventoryUtils.findBlock(Blocks.OBSIDIAN);
-                            if(newSlot == -1) return;
-                            else MC.player.inventory.selectedSlot = newSlot;
-                            WorldUtils.placeBlockMainHand(pos);
-                            MC.player.inventory.selectedSlot = oldSlot;
-                            return;
+                if (MC.player.distanceTo(player) <= range.getValue()) {
+                    for (BlockPos pos : getPos(player)) {
+                        if (MC.world.getBlockState(pos).getMaterial().isReplaceable()) {
+                            if (
+                                    MC.world.getOtherEntities(
+                                            null,
+                                            new Box(pos)
+                                    ).isEmpty()
+                            ) {
+                                //place block
+                                int oldSlot = MC.player.inventory.selectedSlot;
+                                int newSlot = InventoryUtils.findBlock(Blocks.OBSIDIAN);
+                                if (newSlot == -1) return;
+                                else MC.player.inventory.selectedSlot = newSlot;
+                                WorldUtils.placeBlockMainHand(pos, rotate.getValue());
+                                MC.player.inventory.selectedSlot = oldSlot;
+                                delayTimer.reset();
+                                return;
+                            }
                         }
                     }
                 }
@@ -58,7 +66,7 @@ public class AutoTrap extends Module {
         BlockPos playerPos = new BlockPos(player.getPos());
         BlockPos[] blocks;
 
-        if(mode.getValue() == Mode.FULL) {
+        if(mode.getValue() == Mode.Full) {
             blocks = new BlockPos[]{
                     playerPos.add(1, -1, 0),
                     playerPos.add(1, 0, 0),
@@ -78,6 +86,34 @@ public class AutoTrap extends Module {
 
                     playerPos.add(1, 2, 0),
                     playerPos.add(0, 2, 0)
+            };
+        } else if (mode.getValue() == Mode.CrystalAir) {
+            blocks = new BlockPos[]{
+                    playerPos.add(0, 1, 1),
+                    playerPos.add(0, 1, -1),
+                    playerPos.add(1, 1, 0),
+                    playerPos.add(-1, 1, 0),
+
+                    playerPos.add(1, 2, 0),
+                    playerPos.add(0, 2, 0)
+            };
+        } else if(mode.getValue() == Mode.TopOnly) {
+            blocks = new BlockPos[]{
+                    playerPos.add(0, 2, 0)
+            };
+        } else if (mode.getValue() == Mode.TopOnly3x3) {
+            blocks = new BlockPos[]{
+                    playerPos.add(0, 2, 0),
+
+                    playerPos.add(1, 2, 0),
+                    playerPos.add(0, 2, 1),
+                    playerPos.add(-1, 2, 0),
+                    playerPos.add(0, 2, -1),
+
+                    playerPos.add(1, 2, 1),
+                    playerPos.add(1, 2, -1),
+                    playerPos.add(-1, 2, -1),
+                    playerPos.add(-1, 2, 1)
             };
         } else {
             blocks = new BlockPos[]{
@@ -109,6 +145,4 @@ public class AutoTrap extends Module {
 
         return blocks;
     }
-
-    enum Mode {FULL, CRYSTAL}
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Burrow.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Burrow.java
@@ -7,6 +7,7 @@ import dev.tigr.ares.core.setting.settings.*;
 import dev.tigr.ares.core.setting.settings.numerical.*;
 import dev.tigr.ares.core.util.global.ReflectionHelper;
 import dev.tigr.ares.core.util.render.TextColor;
+import dev.tigr.ares.fabric.impl.modules.movement.NoBlockPush;
 import dev.tigr.ares.fabric.utils.HoleType;
 import dev.tigr.ares.fabric.utils.InventoryUtils;
 import dev.tigr.ares.fabric.utils.WorldUtils;
@@ -19,79 +20,77 @@ import net.minecraft.util.math.BlockPos;
 
 /**
  * @author Makrennel
- * Built in Timer for FastMode TPS adapted from Timer Module
  */
 @Module.Info(name = "Burrow", description = "Places a block inside your feet", category = Category.COMBAT)
 public class Burrow extends Module {
-
-    private final Setting<Double> height = register(new DoubleSetting("Height", 1.12, 1.0, 1.3));
-    private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", true));
-    private final Setting<Boolean> autoReturn = register(new BooleanSetting("Auto Switch Return", true));
-    private final Setting<Boolean> holeOnly = register(new BooleanSetting("Hole Only", true));
+    private final Setting<Boolean> holeOnly = register(new BooleanSetting("Hole Only", false));
     private final Setting<Boolean> toggleSurround = register(new BooleanSetting("Toggle Surround On", false));
-    private final Setting<FastMode> fastMode = register(new EnumSetting<>("Fast Mode", FastMode.NONE));
-    private final Setting<Integer> timerModeTPS = register(new IntegerSetting("FastMode-TPS", 2500, 1, 30000));
-    private final Setting<CurrBlock> blockToUse = register(new EnumSetting<>("Block", CurrBlock.OBSIDIAN));
-    private final Setting<HoleBlock> holeBlock = register(new EnumSetting<>("In Hole", HoleBlock.OBSIDIAN));
-    private final Setting<BackBlock> backupBlock = register(new EnumSetting<>("Backup", BackBlock.ENDER_CHEST));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", false));
+    private final Setting<Boolean> preventBlockPush = register(new BooleanSetting("Prevent Block Push", true));
 
-    enum FastMode {NONE, TPS}
-    enum CurrBlock {OBSIDIAN, ENDER_CHEST, CRYING_OBSIDIAN, NETHERITE_BLOCK, ANCIENT_DEBRIS, ENCHANTING_TABLE, ANVIL}
-    enum HoleBlock {OBSIDIAN, ENDER_CHEST, CRYING_OBSIDIAN, NETHERITE_BLOCK, ANCIENT_DEBRIS, ENCHANTING_TABLE, ANVIL}
-    enum BackBlock {OBSIDIAN, ENDER_CHEST, CRYING_OBSIDIAN, NETHERITE_BLOCK, ANCIENT_DEBRIS, ENCHANTING_TABLE, ANVIL}
+    private final Setting<Mode> setMode = register(new EnumSetting<>("Mode", Mode.Instant));
+    private final Setting<Integer> timerModeTimer = register(new IntegerSetting("FastMode-Timer", 2500, 1, 30000)).setVisibility(() -> setMode.getValue() == Mode.NormalTimer || setMode.getValue() == Mode.SemiInstantTimer);
+    private final Setting<Double> height = register(new DoubleSetting("Trigger Height", 1.12, 1.0, 1.3)).setVisibility(() -> setMode.getValue() != Mode.Instant);
+    private final Setting<Float> fakeClipHeight = register(new FloatSetting("Rubberband Height", 12, -60, 60)).setVisibility(() -> setMode.getValue() != Mode.NormalTimer || setMode.getValue() != Mode.Normal);;
+
+    private final Setting<CurrBlock> blockToUse = register(new EnumSetting<>("Block", CurrBlock.Obsidian));
+    private final Setting<CurrBlock> backupBlock = register(new EnumSetting<>("Backup", CurrBlock.EnderChest));
+
+    enum Mode {Normal, NormalTimer, SemiInstant, SemiInstantTimer, Instant}
+    enum CurrBlock {Obsidian, EnderChest, CryingObsidian, NetheriteBlock, AncientDebris, EnchantingTable, RespawnAnchor, Anvil}
 
     private BlockPos playerPos;
-    private BlockPos airAbove;
-
-    private double jumpHeight;
 
     float oldYaw;
     float oldPitch;
 
+    int oldSelection = -1;
+
     //get the Block value of all three options selected
     private Block getCurrBlock(){
-        Block current = null;
-        if (blockToUse.getValue() == CurrBlock.OBSIDIAN) {current = Blocks.OBSIDIAN;}
-        else if (blockToUse.getValue() == CurrBlock.ENDER_CHEST) {current = Blocks.ENDER_CHEST;}
-        else if (blockToUse.getValue() == CurrBlock.CRYING_OBSIDIAN) {current = Blocks.CRYING_OBSIDIAN;}
-        else if (blockToUse.getValue() == CurrBlock.NETHERITE_BLOCK) {current = Blocks.NETHERITE_BLOCK;}
-        else if (blockToUse.getValue() == CurrBlock.ANCIENT_DEBRIS) {current = Blocks.ANCIENT_DEBRIS;}
-        else if (blockToUse.getValue() == CurrBlock.ENCHANTING_TABLE) {current = Blocks.ENCHANTING_TABLE;}
-        else if (blockToUse.getValue() == CurrBlock.ANVIL) {current = Blocks.ANVIL;}
-        return current;
-    }
-    private Block getHoleBlock(){
-        Block hole = null;
-        if (holeBlock.getValue() == HoleBlock.OBSIDIAN) {hole = Blocks.OBSIDIAN;}
-        else if (holeBlock.getValue() == HoleBlock.ENDER_CHEST) {hole = Blocks.ENDER_CHEST;}
-        else if (holeBlock.getValue() == HoleBlock.CRYING_OBSIDIAN) {hole = Blocks.CRYING_OBSIDIAN;}
-        else if (holeBlock.getValue() == HoleBlock.NETHERITE_BLOCK) {hole = Blocks.NETHERITE_BLOCK;}
-        else if (holeBlock.getValue() == HoleBlock.ANCIENT_DEBRIS) {hole = Blocks.ANCIENT_DEBRIS;}
-        else if (holeBlock.getValue() == HoleBlock.ENCHANTING_TABLE) {hole = Blocks.ENCHANTING_TABLE;}
-        else if (holeBlock.getValue() == HoleBlock.ANVIL) {hole = Blocks.ANVIL;}
-        return hole;
+        Block index = null;
+        if (blockToUse.getValue() == CurrBlock.Obsidian) {index = Blocks.OBSIDIAN;}
+        else if (blockToUse.getValue() == CurrBlock.EnderChest) {index = Blocks.ENDER_CHEST;}
+        else if (blockToUse.getValue() == CurrBlock.CryingObsidian) {index = Blocks.CRYING_OBSIDIAN;}
+        else if (blockToUse.getValue() == CurrBlock.NetheriteBlock) {index = Blocks.NETHERITE_BLOCK;}
+        else if (blockToUse.getValue() == CurrBlock.AncientDebris) {index = Blocks.ANCIENT_DEBRIS;}
+        else if (blockToUse.getValue() == CurrBlock.RespawnAnchor) {index = Blocks.RESPAWN_ANCHOR;}
+        else if (blockToUse.getValue() == CurrBlock.EnchantingTable) {index = Blocks.ENCHANTING_TABLE;}
+        else if (blockToUse.getValue() == CurrBlock.Anvil) {index = Blocks.ANVIL;}
+        return index;
     }
     private Block getBackBlock(){
-        Block backup = null;
-        if (backupBlock.getValue() == BackBlock.OBSIDIAN) {backup = Blocks.OBSIDIAN;}
-        else if (backupBlock.getValue() == BackBlock.ENDER_CHEST) {backup = Blocks.ENDER_CHEST;}
-        else if (backupBlock.getValue() == BackBlock.CRYING_OBSIDIAN) {backup = Blocks.CRYING_OBSIDIAN;}
-        else if (backupBlock.getValue() == BackBlock.NETHERITE_BLOCK) {backup = Blocks.NETHERITE_BLOCK;}
-        else if (backupBlock.getValue() == BackBlock.ANCIENT_DEBRIS) {backup = Blocks.ANCIENT_DEBRIS;}
-        else if (backupBlock.getValue() == BackBlock.ENCHANTING_TABLE) {backup = Blocks.ENCHANTING_TABLE;}
-        else if (backupBlock.getValue() == BackBlock.ANVIL) {backup = Blocks.ANVIL;}
-        return backup;
+        Block index = null;
+        if (backupBlock.getValue() == CurrBlock.Obsidian) {index = Blocks.OBSIDIAN;}
+        else if (backupBlock.getValue() == CurrBlock.EnderChest) {index = Blocks.ENDER_CHEST;}
+        else if (backupBlock.getValue() == CurrBlock.CryingObsidian) {index = Blocks.CRYING_OBSIDIAN;}
+        else if (backupBlock.getValue() == CurrBlock.NetheriteBlock) {index = Blocks.NETHERITE_BLOCK;}
+        else if (backupBlock.getValue() == CurrBlock.AncientDebris) {index = Blocks.ANCIENT_DEBRIS;}
+        else if (backupBlock.getValue() == CurrBlock.RespawnAnchor) {index = Blocks.RESPAWN_ANCHOR;}
+        else if (backupBlock.getValue() == CurrBlock.EnchantingTable) {index = Blocks.ENCHANTING_TABLE;}
+        else if (backupBlock.getValue() == CurrBlock.Anvil) {index = Blocks.ANVIL;}
+        return index;
+    }
+
+    private void switchToBlock() {
+        //main block
+        if (!(InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0)) {
+            oldSelection = MC.player.inventory.selectedSlot;
+            MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getCurrBlock());
+        }
+        //backup block to use when either is unavailable
+        else if (!(InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0)) {
+            oldSelection = MC.player.inventory.selectedSlot;
+            MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getBackBlock());
+        }
     }
 
     @Override
     public void onEnable() {
         playerPos = new BlockPos(MC.player.getX(), MC.player.getY(), MC.player.getZ());
-        double airAboveY = playerPos.getY() + 3;
-        airAbove = new BlockPos(playerPos.getX(), airAboveY, playerPos.getZ());
-        double eTableHeight = height.getValue() - 0.25;
 
         //determine if player is already burrowed
-        if (MC.world.getBlockState(playerPos).getBlock() == getCurrBlock() || MC.world.getBlockState(playerPos).getBlock() == getBackBlock() || MC.world.getBlockState(playerPos).getBlock() == getHoleBlock() || MC.world.getBlockState(playerPos).getBlock() == Blocks.ENCHANTING_TABLE) {
+        if (MC.world.getBlockState(playerPos).getBlock() == getCurrBlock() || MC.world.getBlockState(playerPos).getBlock() == getBackBlock()) {
             UTILS.printMessage(TextColor.BLUE + "Already Burrowed!");
             setEnabled(false);
             return;
@@ -104,24 +103,16 @@ public class Burrow extends Module {
             return;
         }
 
-        //checks there is enough space above player, and automatically changes height if not so enchanting table can be used if in hotbar.
-        if (MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
-            if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) > 0) {
-                jumpHeight = eTableHeight;
-            }
-            else if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) {
-                UTILS.printMessage(TextColor.RED + "Not enough space above!");
-                setEnabled(false);
-                return;
-            }
-        }
-        else jumpHeight = height.getValue();
-
         //checks that player has the blocks needed available
-        if (InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0 && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0 || InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0 && WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0){
+        if (InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0 && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0) {
             UTILS.printMessage(TextColor.RED + "No Burrow Blocks Found!");
             setEnabled(false);
             return;
+        }
+
+        //toggles on NoBurrowPush
+        if(preventBlockPush.getValue()) {
+            NoBlockPush.INSTANCE.setEnabled(true);
         }
 
         //toggles Surround with snap turned off (snap breaks burrow)
@@ -130,13 +121,15 @@ public class Burrow extends Module {
             Surround.toggleCenter(false);
         }
 
-        //turns on Timer if Fast Mode is set to TPS
-        if (fastMode.getValue() == FastMode.TPS) {
-            ReflectionHelper.setPrivateValue(RenderTickCounter.class, ReflectionHelper.getPrivateValue(MinecraftClient.class, MC, "renderTickCounter", "field_1728"), 1000.0F / timerModeTPS.getValue(), "tickTime", "field_1968");
+        //turns on Timer if Fast Mode is set to Timer
+        if (setMode.getValue() == Mode.SemiInstantTimer || setMode.getValue() == Mode.NormalTimer) {
+            ReflectionHelper.setPrivateValue(RenderTickCounter.class, ReflectionHelper.getPrivateValue(MinecraftClient.class, MC, "renderTickCounter", "field_1728"), 1000.0F / timerModeTimer.getValue(), "tickTime", "field_1968");
         }
 
-        //jump
-        MC.player.jump();
+        //jump if not Instant mode
+        if (setMode.getValue() != Mode.Instant) {
+            MC.player.jump();
+        }
     }
     public void onTick() {
         //run the main sequence
@@ -144,56 +137,49 @@ public class Burrow extends Module {
     }
     public void onDisable() {
         //turns off Timer
-        if(fastMode.getValue() == FastMode.TPS) {
+        if(setMode.getValue() == Mode.SemiInstantTimer || setMode.getValue() == Mode.NormalTimer) {
             ReflectionHelper.setPrivateValue(RenderTickCounter.class, ReflectionHelper.getPrivateValue(MinecraftClient.class, MC, "renderTickCounter", "field_1728"), 1000.0F / 20.0F, "tickTime", "field_1968");
         }
-        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(oldYaw, oldPitch, MC.player.isOnGround()));
+        if (rotate.getValue()) {
+            MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(oldYaw, oldPitch, MC.player.isOnGround()));
+        }
     }
     public void run() {
         if (MC.player == null || MC.world == null) return;
 
-        int oldSelection = -1;
         oldYaw = MC.player.yaw;
         oldPitch = MC.player.pitch;
 
-        if (MC.player.getY() >= playerPos.getY() + jumpHeight) {
-            //main block to use
-            if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) && MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
-                oldSelection = MC.player.inventory.selectedSlot;
-                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(Blocks.ENCHANTING_TABLE);
-            }
+        switchToBlock();
 
-            //block when in hole
-            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0) && WorldUtils.isHole(MC.player.getBlockPos()) != HoleType.NONE) {
-                oldSelection = MC.player.inventory.selectedSlot;
-                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getHoleBlock());
-            }
-
-            //main block
-            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0)) {
-                oldSelection = MC.player.inventory.selectedSlot;
-                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getCurrBlock());
-            }
-
-            //backup block to use when either is unavailable
-            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0)) {
-                oldSelection = MC.player.inventory.selectedSlot;
-                MC.player.inventory.selectedSlot = InventoryUtils.findBlockInHotbar(getBackBlock());
-            }
-
-            //place block where the player was before jumping
-            WorldUtils.placeBlockMainHand(playerPos);
-
-            //switches back to initial item held if both Auto Switch and Auto Switch Return are true
-            if (autoSwitch.getValue() && autoReturn.getValue()) {
-                MC.player.inventory.selectedSlot = oldSelection;
-            }
-
-            //jumps again to snap player down
-            MC.player.jump();
-
-            //disable module
-            setEnabled(false);
+        if (setMode.getValue() == Mode.Instant) {
+            WorldUtils.fakeJump();
+            runSequence();
         }
+
+        if (setMode.getValue() != Mode.Instant) {
+            if (MC.player.getY() >= playerPos.getY() + height.getValue()) {
+                runSequence();
+            }
+        }
+    }
+
+    private void runSequence(){
+        //place block where the player was before jumping
+        if (MC.player.inventory.selectedSlot == -1) {
+            setEnabled(false);
+        } else WorldUtils.placeBlockMainHand(playerPos, rotate.getValue(), true);
+
+
+        //switches back to initial item held if both Auto Switch and Auto Switch Return are true
+        MC.player.inventory.selectedSlot = oldSelection;
+
+        //tries to produce a rubberband
+        if (setMode.getValue() == Mode.Instant || setMode.getValue() == Mode.SemiInstant || setMode.getValue() == Mode.SemiInstantTimer) {
+            MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionOnly(MC.player.getX(), MC.player.getY() + fakeClipHeight.getValue(), MC.player.getZ(), false));
+        } else MC.player.jump();
+
+        //disable module
+        setEnabled(false);
     }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
@@ -11,6 +11,7 @@ import dev.tigr.ares.core.setting.settings.numerical.FloatSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
 import dev.tigr.ares.core.util.global.ReflectionHelper;
 import dev.tigr.ares.core.util.global.Utils;
+import dev.tigr.ares.core.util.render.TextColor;
 import dev.tigr.ares.fabric.event.client.EntityEvent;
 import dev.tigr.ares.fabric.event.client.PacketEvent;
 import dev.tigr.ares.fabric.event.player.DestroyBlockEvent;
@@ -37,10 +38,8 @@ import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import net.minecraft.network.packet.c2s.play.UpdateSelectedSlotC2SPacket;
-import net.minecraft.network.packet.s2c.play.PlaySoundS2CPacket;
+import net.minecraft.network.packet.s2c.play.ExplosionS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -65,10 +64,10 @@ public class CrystalAura extends Module {
     private final Setting<Order> order = register(new EnumSetting<>("Order", Order.PLACE_BREAK));
     private final Setting<Boolean> preventSuicide = register(new BooleanSetting("Prevent Suicide", true));
     private final Setting<Boolean> noGappleSwitch = register(new BooleanSetting("No Gapple Switch", false));
-    private final Setting<Integer> placeDelay = register(new IntegerSetting("Place Delay", 7, 0, 15));
-    private final Setting<Integer> breakDelay = register(new IntegerSetting("Break Delay", 5, 0, 15));
-    private final Setting<Integer> placeOffhandDelay = register(new IntegerSetting("Offh. Place Delay", 3, 0, 15));
-    private final Setting<Integer> breakOffhandDelay = register(new IntegerSetting("Offh. Break Delay", 3, 0, 15));
+    private final Setting<Integer> placeDelay = register(new IntegerSetting("Place Delay", 2, 0, 15));
+    private final Setting<Integer> breakDelay = register(new IntegerSetting("Break Delay", 2, 0, 15));
+    private final Setting<Integer> placeOffhandDelay = register(new IntegerSetting("Offh. Place Delay", 2, 0, 15));
+    private final Setting<Integer> breakOffhandDelay = register(new IntegerSetting("Offh. Break Delay", 2, 0, 15));
     private final Setting<Float> minDamage = register(new FloatSetting("Minimum Damage", 7.5f, 0, 15));
     private final Setting<Double> placeRange = register(new DoubleSetting("Place Range", 5, 0, 10));
     private final Setting<Double> breakRange = register(new DoubleSetting("Break Range", 5, 0, 10));
@@ -77,13 +76,13 @@ public class CrystalAura extends Module {
     private final Setting<Boolean> predictMovement = register(new BooleanSetting("Predict Movement", true));
     private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anti-Surround", true));
     private final Setting<Rotations> rotateMode = register(new EnumSetting<>("Rotations", Rotations.PACKET));
-    private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Canceller", Canceller.NO_DESYNC));
+    private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Cancel", Canceller.NO_DESYNC));
 
     enum Mode { DAMAGE, DISTANCE }
     enum Order { PLACE_BREAK, BREAK_PLACE }
     enum Target { CLOSEST, MOST_DAMAGE }
     enum Rotations { PACKET, REAL, NONE }
-    enum Canceller { NO_DESYNC, ON_HIT, SOUND_PACKET }
+    enum Canceller { NO_DESYNC, ON_HIT, ON_PACKET }
 
     private long renderTimer = -1;
     private long placeTimer = -1;
@@ -94,9 +93,21 @@ public class CrystalAura extends Module {
     private final LinkedHashMap<Vec3d, Long> placedCrystals = new LinkedHashMap<>();
     private final LinkedHashMap<EndCrystalEntity, AtomicInteger> spawnedCrystals = new LinkedHashMap<>();
     private final List<EndCrystalEntity> lostCrystals = new ArrayList<>();
+    private PlayerEntity targetPlayer;
 
     public CrystalAura() {
         INSTANCE = this;
+    }
+
+    @Override
+    public String getInfo() {
+        if (targetPlayer != null
+                && !targetPlayer.isDead()
+                && !(targetPlayer.getHealth() <= 0)
+                && !(MC.player.distanceTo(targetPlayer) > Math.max(placeRange.getValue(), breakRange.getValue()) + 8)) {
+            return targetPlayer.getGameProfile().getName();
+        }
+        else return "null";
     }
 
     @Override
@@ -252,17 +263,15 @@ public class CrystalAura extends Module {
         }
     });
 
-    //Cancel Crystals if on SOUND_PACKET
+    //Cancel Crystals on Explosion packet received
     @EventHandler
     private EventListener<PacketEvent.Receive> packetReceiveListener = new EventListener<>(event -> {
-        if (event.getPacket() instanceof PlaySoundS2CPacket && cancelMode.getValue() == Canceller.SOUND_PACKET) {
-            final PlaySoundS2CPacket packet = (PlaySoundS2CPacket) event.getPacket();
-            if (packet.getCategory() == SoundCategory.BLOCKS && packet.getSound() == SoundEvents.ENTITY_GENERIC_EXPLODE) {
-                for (Entity e : MC.world.getEntities()) {
-                    if (e instanceof EndCrystalEntity) {
-                        if (e.squaredDistanceTo(packet.getX(), packet.getY(), packet.getZ()) <= 6.0f) {
-                            MC.world.removeEntity(e.getEntityId());
-                        }
+        if (event.getPacket() instanceof ExplosionS2CPacket && cancelMode.getValue() != Canceller.NO_DESYNC ) {
+            final ExplosionS2CPacket packet = (ExplosionS2CPacket) event.getPacket();
+            for (Entity e : MC.world.getEntities()) {
+                if (e instanceof EndCrystalEntity) {
+                    if (MathHelper.sqrt(e.squaredDistanceTo(packet.getX(), packet.getY(), packet.getZ())) <= Math.max(breakRange.getValue(), placeRange.getValue()) + 2) {
+                        e.remove();
                     }
                 }
             }
@@ -302,7 +311,7 @@ public class CrystalAura extends Module {
 
     private boolean canBreakCrystal(EndCrystalEntity crystal) {
         return MC.player.distanceTo(crystal) <= breakRange.getValue() // check range
-        && !(MC.player.getHealth() - getDamage(crystal.getPos(), MC.player) <= 1 && preventSuicide.getValue()); // check suicide
+                && !(MC.player.getHealth() - getDamage(crystal.getPos(), MC.player) <= 1 && preventSuicide.getValue()); // check suicide
     }
 
     private void breakCrystal(EndCrystalEntity crystal, boolean offhand) {
@@ -318,7 +327,10 @@ public class CrystalAura extends Module {
         rotations = WorldUtils.calculateLookAt(crystal.getX() + 0.5, crystal.getY() + 0.5, crystal.getZ() + 0.5, MC.player);
 
         //cancel crystal if ON_HIT
-        if(cancelMode.getValue() == Canceller.ON_HIT) MC.world.removeEntity(crystal.getEntityId());
+        if(cancelMode.getValue() == Canceller.ON_HIT) {
+            crystal.remove();
+            MC.world.getEntities();
+        }
 
         // reset timer
         breakTimer = System.nanoTime() / 1000000;
@@ -337,6 +349,9 @@ public class CrystalAura extends Module {
                     continue;
 
                 double score = getScore(pos, targetedPlayer);
+                if (target != null) {
+                    targetPlayer = targetedPlayer;
+                } else targetPlayer = null;
 
                 if(target == null || (score < bestScore && score != -1)) {
                     target = pos;

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
@@ -329,6 +329,7 @@ public class CrystalAura extends Module {
         //cancel crystal if ON_HIT
         if(cancelMode.getValue() == Canceller.ON_HIT) {
             crystal.remove();
+            MC.world.finishRemovingEntities();
             MC.world.getEntities();
         }
 

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/CrystalAura.java
@@ -11,7 +11,6 @@ import dev.tigr.ares.core.setting.settings.numerical.FloatSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
 import dev.tigr.ares.core.util.global.ReflectionHelper;
 import dev.tigr.ares.core.util.global.Utils;
-import dev.tigr.ares.core.util.render.TextColor;
 import dev.tigr.ares.fabric.event.client.EntityEvent;
 import dev.tigr.ares.fabric.event.client.PacketEvent;
 import dev.tigr.ares.fabric.event.player.DestroyBlockEvent;
@@ -77,6 +76,13 @@ public class CrystalAura extends Module {
     private final Setting<Boolean> antiSurround = register(new BooleanSetting("Anti-Surround", true));
     private final Setting<Rotations> rotateMode = register(new EnumSetting<>("Rotations", Rotations.PACKET));
     private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Cancel", Canceller.NO_DESYNC));
+
+    private final Setting<Boolean> showColorSettings = register(new BooleanSetting("Color Settings", false));
+    private final Setting<Integer> colorRed = register(new IntegerSetting("Red", 237, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorGreen = register(new IntegerSetting("Green", 0, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorBlue = register(new IntegerSetting("Blue", 0, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> fillAlpha = register(new IntegerSetting("Fill Alpha", 30, 0, 100)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> boxAlpha = register(new IntegerSetting("Box Alpha", 69, 0, 100)).setVisibility(showColorSettings::getValue);
 
     enum Mode { DAMAGE, DISTANCE }
     enum Order { PLACE_BREAK, BREAK_PLACE }
@@ -282,11 +288,16 @@ public class CrystalAura extends Module {
     @Override
     public void onRender3d() {
         if(target != null) {
+            float red = (float)colorRed.getValue() / 255;
+            float green = (float)colorGreen.getValue() / 255;
+            float blue = (float)colorBlue.getValue() / 255;
+            float fAlpha = (float)fillAlpha.getValue() / 100;
+            float bAlpha = (float)boxAlpha.getValue() / 100;
             RenderUtils.prepare3d();
             Box bb = RenderUtils.getBoundingBox(target);
             if(bb != null) {
-                RenderUtils.renderFilledBox(bb, 0.93f, 0, 0, 0.2f);
-                RenderUtils.renderSelectionBoundingBox(bb, 0.55f, 0, 0, 0.2f);
+                RenderUtils.renderFilledBox(bb, red, green, blue, fAlpha);
+                RenderUtils.renderSelectionBoundingBox(bb, red, green, blue, bAlpha);
             }
             RenderUtils.end3d();
         }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/FireworkAura.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/FireworkAura.java
@@ -1,0 +1,101 @@
+package dev.tigr.ares.fabric.impl.modules.combat;
+
+import dev.tigr.ares.core.feature.FriendManager;
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
+import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
+import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
+import dev.tigr.ares.core.util.render.TextColor;
+import dev.tigr.ares.fabric.utils.Comparators;
+import dev.tigr.ares.fabric.utils.InventoryUtils;
+import dev.tigr.ares.fabric.utils.Timer;
+import dev.tigr.ares.fabric.utils.WorldUtils;
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Items;
+import net.minecraft.network.packet.c2s.play.ClientCommandC2SPacket;
+import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Makrennel
+ */
+@Module.Info(name = "FireworkAura", description = "Automatically traps and places fireworks on other people.", category = Category.COMBAT)
+public class FireworkAura extends Module {
+
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay(ms)", 50, 0, 1000));
+    private final Setting<Integer> trapDelay = register(new IntegerSetting("Trap(ms)", 100, 0, 1000));
+    private final Setting<Double> range = register(new DoubleSetting("Range", 5.0D, 0.0D, 15.0D));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
+
+    private Timer trapTimer = new Timer();
+    private Timer delayTimer = new Timer();
+
+    @Override
+    public void onTick() {
+        // get targets
+        List<PlayerEntity> targets = MC.world.getPlayers().stream().filter(entityPlayer -> !FriendManager.isFriend(entityPlayer.getGameProfile().getName()) && entityPlayer != MC.player).collect(Collectors.toList());
+        targets.sort(Comparators.entityDistance);
+
+        for (PlayerEntity playerEntity : targets) {
+            BlockPos playerPos = playerEntity.getBlockPos();
+            BlockPos trapPos = new BlockPos(playerPos.getX(), playerPos.getY() + 2, playerPos.getZ());
+
+            // place trap
+            if (MC.world.getBlockState(trapPos).getBlock() == Blocks.AIR) {
+                if (trapTimer.passedMillis(trapDelay.getValue())) {
+                    int oldSelection = MC.player.inventory.selectedSlot;
+                    int newSelection = InventoryUtils.getBlockInHotbar();
+                    if (newSelection == -1) {
+                        setEnabled(false);
+                        UTILS.printMessage(TextColor.RED + "No Blocks Found");
+                    } else MC.player.inventory.selectedSlot = newSelection;
+                    WorldUtils.placeBlockMainHand(trapPos, rotate.getValue());
+                    MC.player.inventory.selectedSlot = oldSelection;
+                    delayTimer.reset();
+                    trapTimer.reset();
+                }
+            }
+
+            // place fireworks
+            else if (delayTimer.passedMillis(delay.getValue())) {
+                if (MathHelper.sqrt(MC.player.squaredDistanceTo(playerPos.getX(), playerPos.getY(), playerPos.getZ())) <= range.getValue()) {
+
+                    // switch
+                    int oldSelection = MC.player.inventory.selectedSlot;
+                    int newSelection = InventoryUtils.findItemInHotbar(Items.FIREWORK_ROCKET);
+                    if (newSelection == -1) return;
+                    else MC.player.inventory.selectedSlot = newSelection;
+
+                    // rotate
+                    if (rotate.getValue()) {
+                        double[] rotations = WorldUtils.calculateLookAt(playerPos.getX() + 0.5, playerPos.getY(), playerPos.getZ() + 0.5, MC.player);
+                        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly((float) rotations[0], (float) rotations[1], MC.player.isOnGround()));
+                    }
+                    // place
+                    MC.player.networkHandler.sendPacket(new ClientCommandC2SPacket(MC.player, ClientCommandC2SPacket.Mode.PRESS_SHIFT_KEY));
+                    MC.interactionManager.interactBlock(MC.player, MC.world, Hand.MAIN_HAND, new BlockHitResult(new Vec3d(playerPos.getX() + 0.5, playerPos.getY(), playerPos.getZ() + 0.5), Direction.UP, playerPos, false));
+                    MC.player.swingHand(Hand.MAIN_HAND);
+                    MC.player.networkHandler.sendPacket(new ClientCommandC2SPacket(MC.player, ClientCommandC2SPacket.Mode.RELEASE_SHIFT_KEY));
+
+                    // switch return
+                    MC.player.inventory.selectedSlot = oldSelection;
+
+                    // reset timer
+                    trapTimer.reset();
+                    delayTimer.reset();
+                }
+            }
+        }
+    }
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/HoleFiller.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/HoleFiller.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 @Module.Info(name = "HoleFiller", description = "Automatically fills nearby holes", category = Category.COMBAT)
 public class HoleFiller extends Module {
     private final Setting<Boolean> skipNearby = register(new BooleanSetting("Skip closest", true));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Double> range = register(new DoubleSetting("Range", 5, 0, 10));
 
     @Override
@@ -59,7 +60,7 @@ public class HoleFiller extends Module {
                 }
                 MC.player.inventory.selectedSlot = slot;
 
-                WorldUtils.placeBlockMainHand(hole);
+                WorldUtils.placeBlockMainHand(hole, rotate.getValue());
                 MC.player.inventory.selectedSlot = first;
                 return;
             }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Surround.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/combat/Surround.java
@@ -29,6 +29,7 @@ public class Surround extends Module {
 
     private final Setting<Boolean> snap = register(new BooleanSetting("Center", true));
     private final Setting<Integer> delay = register(new IntegerSetting("Delay", 0, 0, 10));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Boolean> air = register(new BooleanSetting("Air-place", false));
     private final Setting<Primary> primary = register(new EnumSetting<>("Main", Primary.Obsidian));
     private final Setting<Boolean> allBlocks = register(new BooleanSetting("All BP Blocks", true));
@@ -75,7 +76,7 @@ public class Surround extends Module {
             if (needsToPlace()) {
                 for (BlockPos pos : getPositions()) {
                     MC.player.inventory.selectedSlot = obbyIndex;
-                    if (WorldUtils.placeBlockMainHand(pos) && delay.getValue() != 0) return;
+                    if (WorldUtils.placeBlockMainHand(pos, rotate.getValue()) && delay.getValue() != 0) return;
                 }
 
                 MC.player.inventory.selectedSlot = prevSlot;

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/InstantMine.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/InstantMine.java
@@ -38,7 +38,7 @@ public class InstantMine extends Module {
 
     private final Setting<Boolean> repeatMine = register(new BooleanSetting("Repeat", true));
     private final Setting<Double> repeatRange = register(new DoubleSetting("Repeat Range", 5, 0, 10)).setVisibility(repeatMine::getValue);
-    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 120, 0, 1200));
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay(ms)", 120, 0, 1200));
     private final Setting<Boolean> pickOnly = register(new BooleanSetting("Only Pickaxe", true));
     private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", false)).setVisibility(pickOnly::getValue);
     private final Setting<Swing> swingType = register(new EnumSetting<>("Swing", Swing.Real));

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/InstantMine.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/exploit/InstantMine.java
@@ -1,0 +1,152 @@
+package dev.tigr.ares.fabric.impl.modules.exploit;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
+import dev.tigr.ares.core.setting.settings.EnumSetting;
+import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
+import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
+import dev.tigr.ares.core.util.global.ReflectionHelper;
+import dev.tigr.ares.fabric.event.client.PacketEvent;
+import dev.tigr.ares.fabric.event.player.DamageBlockEvent;
+import dev.tigr.ares.fabric.utils.InventoryUtils;
+import dev.tigr.ares.fabric.utils.RenderUtils;
+import dev.tigr.ares.fabric.utils.Timer;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+import net.minecraft.block.BlockState;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.item.Items;
+import net.minecraft.item.PickaxeItem;
+import net.minecraft.network.Packet;
+import net.minecraft.network.packet.c2s.play.HandSwingC2SPacket;
+import net.minecraft.network.packet.c2s.play.PlayerActionC2SPacket;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
+
+/**
+ * @author Makrennel
+ * Credit to Kami147 for the module off which this was based.
+ */
+@Module.Info(name = "InstantMine", description = "Instantly mines blocks after packet mining the first one.", category = Category.EXPLOIT)
+public class InstantMine extends Module {
+    public static InstantMine INSTANCE;
+
+    private final Setting<Boolean> repeatMine = register(new BooleanSetting("Repeat", true));
+    private final Setting<Double> repeatRange = register(new DoubleSetting("Repeat Range", 5, 0, 10)).setVisibility(repeatMine::getValue);
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 120, 0, 1200));
+    private final Setting<Boolean> pickOnly = register(new BooleanSetting("Only Pickaxe", true));
+    private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", false)).setVisibility(pickOnly::getValue);
+    private final Setting<Swing> swingType = register(new EnumSetting<>("Swing", Swing.Real));
+
+    private final Setting<Boolean> showColorSettings = register(new BooleanSetting("Color Settings", false));
+    private final Setting<Integer> colorRed = register(new IntegerSetting("Red", 255, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorGreen = register(new IntegerSetting("Green", 255, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorBlue = register(new IntegerSetting("Blue", 120, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> fillAlpha = register(new IntegerSetting("Fill Alpha", 24, 0, 100)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> boxAlpha = register(new IntegerSetting("Box Alpha", 71, 0, 100)).setVisibility(showColorSettings::getValue);
+
+    enum Swing { None, Real, Packet }
+
+    private Timer repeatTimer = new Timer();
+    private BlockPos last;
+    private BlockPos render;
+    private boolean cancel = false;
+    private Direction direction;
+
+    public InstantMine() {
+        INSTANCE = this;
+    }
+
+    private boolean shouldRepeat = true;
+    public void setShouldRepeat(Boolean shouldRepeat) {
+        INSTANCE.shouldRepeat = shouldRepeat;
+    }
+
+    @EventHandler
+    private EventListener<DamageBlockEvent> damageBlockEvent = new EventListener<>(event -> {
+       if (canBreakBlock(event.getBlockPos())) {
+           if(last == null || event.getBlockPos() != last) {
+               cancel = false;
+               if (swingType.getValue() == Swing.Packet) MC.player.networkHandler.sendPacket(new HandSwingC2SPacket(Hand.MAIN_HAND));
+               else if (swingType.getValue() == Swing.Real) MC.player.swingHand(Hand.MAIN_HAND);
+               MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, event.getBlockPos(), event.getDirection()));
+               cancel = true;
+           } else {
+               if (swingType.getValue() == Swing.Packet) MC.player.networkHandler.sendPacket(new HandSwingC2SPacket(Hand.MAIN_HAND));
+               else if (swingType.getValue() == Swing.Real) MC.player.swingHand(Hand.MAIN_HAND);
+               MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, event.getBlockPos(), event.getDirection()));
+               cancel = true;
+           }
+           MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, event.getBlockPos(), event.getDirection()));
+
+           render = event.getBlockPos();
+           last = event.getBlockPos();
+           direction = event.getDirection();
+
+           event.setCancelled(true);
+       }
+    });
+
+    @EventHandler
+    private EventListener<PacketEvent.Sent> onPacketSent = new EventListener<>(event -> {
+        Packet packet = event.getPacket();
+        if (packet instanceof PlayerActionC2SPacket) {
+            PlayerActionC2SPacket digPacket = (PlayerActionC2SPacket) packet;
+            if(((PlayerActionC2SPacket) packet).getAction() == PlayerActionC2SPacket.Action.START_DESTROY_BLOCK && cancel) event.setCancelled(true);
+        }
+    });
+
+    @Override
+    public void onTick() {
+        if (MathHelper.sqrt(MC.player.squaredDistanceTo(render.getX(), render.getY(), render.getZ())) > repeatRange.getValue())
+            render = null;
+        else if (MathHelper.sqrt(MC.player.squaredDistanceTo(last.getX(), last.getY(), last.getZ())) <= repeatRange.getValue() && render == null)
+            render = last;
+        if (render != null && !MC.world.getBlockState(render).getMaterial().isReplaceable()) {
+            if (repeatMine.getValue() && repeatTimer.passedMillis(delay.getValue())) {
+                if (pickOnly.getValue() && !(MC.player.getStackInHand(Hand.MAIN_HAND).getItem() instanceof PickaxeItem)) {
+                    if (autoSwitch.getValue()) {
+                        int newSelection = InventoryUtils.findItemInHotbar(Items.NETHERITE_PICKAXE);
+                        if (newSelection == -1) newSelection = InventoryUtils.findItemInHotbar(Items.DIAMOND_PICKAXE);
+                        if (newSelection != -1) MC.player.inventory.selectedSlot = newSelection;
+                        else return;
+                    } else return;
+                }
+                MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.START_DESTROY_BLOCK, render, direction));
+                if (swingType.getValue() == Swing.Packet) MC.player.networkHandler.sendPacket(new HandSwingC2SPacket(Hand.MAIN_HAND));
+                else if (swingType.getValue() == Swing.Real) MC.player.swingHand(Hand.MAIN_HAND);
+                MC.player.networkHandler.sendPacket(new PlayerActionC2SPacket(PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK, render, direction));
+                repeatTimer.reset();
+            }
+        }
+        ReflectionHelper.setPrivateValue(ClientPlayerInteractionManager.class, MC.interactionManager, 0, "blockBreakingCooldown", "field_3716");
+    }
+
+    private boolean canBreakBlock(BlockPos blockPos) {
+        final BlockState blockState = MC.world.getBlockState(blockPos);
+        return blockState.getHardness(MC.world, blockPos) != -1;
+    }
+
+    @Override
+    public void onRender3d() {
+        float red = (float)colorRed.getValue() / 255;
+        float green = (float)colorGreen.getValue() / 255;
+        float blue = (float)colorBlue.getValue() / 255;
+        float fAlpha = (float)fillAlpha.getValue() / 100;
+        float bAlpha = (float)boxAlpha.getValue() / 100;
+        if(this.render != null) {
+            RenderUtils.prepare3d();
+            Box bb = RenderUtils.getBoundingBox(this.render);
+            if(bb != null) {
+                RenderUtils.renderFilledBox(bb, red, green, blue, fAlpha);
+                RenderUtils.renderSelectionBoundingBox(bb, red, green, blue, bAlpha);
+            }
+            RenderUtils.end3d();
+        }
+    }
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/movement/NoBlockPush.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/movement/NoBlockPush.java
@@ -1,0 +1,25 @@
+package dev.tigr.ares.fabric.impl.modules.movement;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.fabric.event.movement.BlockPushEvent;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+
+/**
+ * @author Makrennel
+ * This is seperated from burrow because burrow toggles off after use.
+ */
+@Module.Info(name = "NoBlockPush", description = "Prevents full blocks from pushing you out (eg. When burrowed).", category = Category.MOVEMENT)
+public class NoBlockPush extends Module {
+    public static NoBlockPush INSTANCE;
+
+    public NoBlockPush() {
+        INSTANCE = this;
+    }
+
+    @EventHandler
+    public EventListener<BlockPushEvent> onBurrowPush = new EventListener<>(event -> {
+        event.setCancelled(true);
+    });
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/player/Scaffold.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/player/Scaffold.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 @Module.Info(name = "Scaffold", description = "Automatically bridges for you", category = Category.PLAYER)
 public class Scaffold extends Module {
     private final Setting<Integer> radius = register(new IntegerSetting("Radius", 0, 0, 2));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Boolean> down = register(new BooleanSetting("Down", false));
     @EventHandler
     public EventListener<WalkOffLedgeEvent> walkOffLedgeEvent = new EventListener<>(event -> {
@@ -64,7 +65,7 @@ public class Scaffold extends Module {
 
             BlockPos under = new BlockPos(MC.player.getX(), MC.player.getY() - 2, MC.player.getZ());
 
-            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under);
+            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under, rotate.getValue());
 
             MC.player.inventory.selectedSlot = oldSlot;
 
@@ -75,7 +76,7 @@ public class Scaffold extends Module {
         if(radius.getValue() == 0) {
             BlockPos under = new BlockPos(MC.player.getX(), MC.player.getY() - 1, MC.player.getZ());
 
-            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under);
+            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under, rotate.getValue());
 
             MC.player.inventory.selectedSlot = oldSlot;
 
@@ -92,7 +93,7 @@ public class Scaffold extends Module {
 
         for(BlockPos x: blocks) {
             if(MC.world.getBlockState(x).getMaterial().isReplaceable()) {
-                WorldUtils.placeBlockMainHand(x);
+                WorldUtils.placeBlockMainHand(x, rotate.getValue());
                 break;
             }
         }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerEntity.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerEntity.java
@@ -5,6 +5,7 @@ import dev.tigr.ares.core.Ares;
 import dev.tigr.ares.core.event.render.PortalChatEvent;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.util.global.ReflectionHelper;
+import dev.tigr.ares.fabric.event.movement.BlockPushEvent;
 import dev.tigr.ares.fabric.event.movement.EntityClipEvent;
 import dev.tigr.ares.fabric.event.movement.MovePlayerEvent;
 import dev.tigr.ares.fabric.event.movement.SlowDownEvent;
@@ -39,6 +40,12 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
     @Inject(method = "pushOutOfBlocks", at = @At("HEAD"), cancellable = true)
     public void pushOutOfBlocks(double d, double d1, CallbackInfo ci) {
         if(Ares.EVENT_MANAGER.post(new EntityClipEvent(clientPlayerEntity)).isCancelled()) ci.cancel();
+    }
+
+    @Inject(method = "pushOutOfBlocks", at = @At("HEAD"), cancellable = true)
+    public void noPushOutOfBlocks(double var1, double var2, CallbackInfo ci) {
+        BlockPushEvent blockPushEvent = Ares.EVENT_MANAGER.post((new BlockPushEvent(var1, var2)));
+        if (Ares.EVENT_MANAGER.post(new BlockPushEvent(var1, var2)).isCancelled()) ci.cancel();
     }
 
     @Inject(method = "tickMovement", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;isUsingItem()Z", ordinal = 0))

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerEntity.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerEntity.java
@@ -9,10 +9,12 @@ import dev.tigr.ares.fabric.event.movement.BlockPushEvent;
 import dev.tigr.ares.fabric.event.movement.EntityClipEvent;
 import dev.tigr.ares.fabric.event.movement.MovePlayerEvent;
 import dev.tigr.ares.fabric.event.movement.SlowDownEvent;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MovementType;
 import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
@@ -56,14 +58,19 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
         }
     }
 
+    @Inject(method = "move", at = @At("HEAD"))
+    private void onMove(MovementType type, Vec3d movement, CallbackInfo info) {
+        Ares.EVENT_MANAGER.post(new MovePlayerEvent(type, movement.x, movement.y, movement.z));
+    }
+
     @Redirect(method = "updateNausea", at = @At(value = "FIELD", target = "Lnet/minecraft/client/network/ClientPlayerEntity;inNetherPortal:Z", ordinal = 0))
     public boolean portalChat(ClientPlayerEntity clientPlayerEntity) {
         return (boolean) ReflectionHelper.getPrivateValue(Entity.class, clientPlayerEntity, "inNetherPortal", "field_5963") && !Ares.EVENT_MANAGER.post(new PortalChatEvent()).isCancelled();
     }
 
-    @Redirect(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;move(Lnet/minecraft/entity/MovementType;Lnet/minecraft/util/math/Vec3d;)V"))
-    public void movePlayer(AbstractClientPlayerEntity abstractClientPlayerEntity, MovementType type, Vec3d movement) {
-        MovePlayerEvent event = Ares.EVENT_MANAGER.post(new MovePlayerEvent(type, movement.x, movement.y, movement.z));
-        if(!event.isCancelled()) super.move(type, new Vec3d(event.getX(), event.getY(), event.getZ()));
-    }
+//    @Redirect(method = "move", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/AbstractClientPlayerEntity;move(Lnet/minecraft/entity/MovementType;Lnet/minecraft/util/math/Vec3d;)V"))
+//    public void movePlayer(AbstractClientPlayerEntity abstractClientPlayerEntity, MovementType type, Vec3d movement) {
+//        MovePlayerEvent event = Ares.EVENT_MANAGER.post(new MovePlayerEvent(type, movement.x, movement.y, movement.z));
+//        if(!event.isCancelled()) super.move(type, new Vec3d(event.getX(), event.getY(), event.getZ()));
+//    }
 }

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/Timer.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/Timer.java
@@ -1,0 +1,73 @@
+package dev.tigr.ares.fabric.utils;
+
+/**
+ * @author Makrennel
+ */
+
+public class Timer {
+
+    private long nanoTime = -1L;
+
+    public void reset() {
+        nanoTime = System.nanoTime();
+    }
+
+    // All setters
+    public void setTicks(long ticks) { nanoTime = System.nanoTime() - convertTicksToNano(ticks); }
+
+    public void setNano(long time) { nanoTime = System.nanoTime() - time; }
+
+    public void setMicro(long time) { nanoTime = System.nanoTime() - convertMicroToNano(time); }
+
+    public void setMillis(long time) { nanoTime = System.nanoTime() - convertMillisToNano(time); }
+
+    public void setSec(long time) { nanoTime = System.nanoTime() - convertSecToNano(time); }
+
+    // All getters
+    public long getTicks() { return convertNanoToTicks(nanoTime); }
+
+    public long getNano() { return nanoTime; }
+
+    public long getMicro() { return convertNanoToMicro(nanoTime); }
+
+    public long getMillis() { return convertNanoToMillis(nanoTime); }
+
+    public long getSec() { return convertNanoToSec(nanoTime); }
+
+    // All passed
+    public boolean passedTicks(long ticks) { return passedNano(convertTicksToNano(ticks)); }
+
+    public boolean passedNano(long time) { return System.nanoTime() - nanoTime >= time; }
+
+    public boolean passedMicro(long time) { return passedNano(convertMicroToNano(time)); }
+
+    public boolean passedMillis(long time) { return passedNano(convertMillisToNano(time)); }
+
+    public boolean passedSec(long time) { return passedNano(convertSecToNano(time)); }
+
+    // Tick Conversions
+    public long convertMillisToTicks(long time) { return time / 50; }
+    public long convertTicksToMillis(long ticks) { return ticks * 50; }
+    public long convertNanoToTicks(long time) { return convertMillisToTicks(convertNanoToMillis(time)); }
+    public long convertTicksToNano(long ticks) { return convertMillisToNano(convertTicksToMillis(ticks)); }
+
+    // All Conversions To Smaller
+    public long convertSecToMillis(long time) { return time * 1000L; }
+    public long convertSecToMicro(long time) { return convertMillisToMicro(convertSecToMillis(time)); }
+    public long convertSecToNano(long time) { return convertMicroToNano(convertMillisToMicro(convertSecToMillis(time))); }
+
+    public long convertMillisToMicro(long time) { return time * 1000L; }
+    public long convertMillisToNano(long time) { return convertMicroToNano(convertMillisToMicro(time)); }
+
+    public long convertMicroToNano(long time) { return time * 1000L; }
+
+    // All Conversions To Larger
+    public long convertNanoToMicro(long time) { return time / 1000L; }
+    public long convertNanoToMillis(long time) { return convertMicroToMillis(convertNanoToMicro(time)); }
+    public long convertNanoToSec(long time) { return convertMillisToSec(convertMicroToMillis(convertNanoToMicro(time))); }
+
+    public long convertMicroToMillis(long time) { return time / 1000L; }
+    public long convertMicroToSec(long time) { return convertMillisToSec(convertMicroToMillis(time)); }
+
+    public long convertMillisToSec(long time) { return time / 1000L; }
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/WorldUtils.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/WorldUtils.java
@@ -34,48 +34,37 @@ import java.util.stream.StreamSupport;
  */
 public class WorldUtils implements Wrapper {
     public static boolean placeBlockMainHand(BlockPos pos) {
-        return placeBlock(Hand.MAIN_HAND, pos);
+        return placeBlockMainHand(pos, true, false);
+    }
+
+    public static boolean placeBlockMainHand(BlockPos pos, Boolean rotate) {
+        return placeBlockMainHand(pos, rotate, false);
+    }
+
+    public static boolean placeBlockMainHand(BlockPos pos, Boolean rotate, Boolean ignoreEntity) {
+        return placeBlock(Hand.MAIN_HAND, pos, rotate, ignoreEntity);
     }
 
     public static boolean placeBlockNoRotate(Hand hand, BlockPos pos) {
-        // make sure place is empty
-        if(!MC.world.getBlockState(pos).getMaterial().isReplaceable() || !MC.world.canPlace(Blocks.OBSIDIAN.getDefaultState(), pos, ShapeContext.absent()))
-            return false;
-
-        Vec3d hitVec = null;
-        BlockPos neighbor = null;
-        Direction side2 = null;
-        for(Direction side: Direction.values()) {
-            neighbor = pos.offset(side);
-            side2 = side.getOpposite();
-
-            // check if neighbor can be right clicked aka it isnt air
-            if(MC.world.getBlockState(neighbor).isAir()) {
-                neighbor = null;
-                side2 = null;
-                continue;
-            }
-
-            hitVec = new Vec3d(neighbor.getX(), neighbor.getY(), neighbor.getZ()).add(0.5, 0.5, 0.5).add(new Vec3d(side2.getUnitVector()).multiply(0.5));
-            break;
-        }
-
-        // Air place if no neighbour was found
-        if(hitVec == null) hitVec = new Vec3d(pos.getX(), pos.getY(), pos.getZ());
-        if(neighbor == null) neighbor = pos;
-        if(side2 == null) side2 = Direction.UP;
-
-        MC.player.networkHandler.sendPacket(new ClientCommandC2SPacket(MC.player, ClientCommandC2SPacket.Mode.PRESS_SHIFT_KEY));
-        MC.interactionManager.interactBlock(MC.player, MC.world, hand, new BlockHitResult(hitVec, side2, neighbor, false));
-        MC.player.swingHand(hand);
-        MC.player.networkHandler.sendPacket(new ClientCommandC2SPacket(MC.player, ClientCommandC2SPacket.Mode.RELEASE_SHIFT_KEY));
-
-        return true;
+        return placeBlock(hand, pos, false, false);
     }
 
     public static boolean placeBlock(Hand hand, BlockPos pos) {
-        // make sure place is empty
-        if(!MC.world.getBlockState(pos).getMaterial().isReplaceable() || !MC.world.canPlace(Blocks.OBSIDIAN.getDefaultState(), pos, ShapeContext.absent()))
+        placeBlock(hand, pos, true, false);
+        return true;
+    }
+
+    public static boolean placeBlock(Hand hand, BlockPos pos, Boolean rotate) {
+        placeBlock(hand, pos, rotate, false);
+        return true;
+    }
+
+    public static boolean placeBlock(Hand hand, BlockPos pos, Boolean rotate, Boolean ignoreEntity) {
+        // make sure place is empty if ignoreEntity is not true
+        if (ignoreEntity) {
+            if (!MC.world.getBlockState(pos).getMaterial().isReplaceable())
+                return false;
+        } else if (!MC.world.getBlockState(pos).getMaterial().isReplaceable() || !MC.world.canPlace(Blocks.OBSIDIAN.getDefaultState(), pos, ShapeContext.absent()))
             return false;
 
         Vec3d eyesPos = new Vec3d(MC.player.getX(),
@@ -121,7 +110,9 @@ public class WorldUtils implements Wrapper {
                 MC.player.pitch + MathHelper
                         .wrapDegrees(pitch - MC.player.pitch)};
 
-        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(rotations[0], rotations[1], MC.player.isOnGround()));
+        if (rotate) {
+            MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(rotations[0], rotations[1], MC.player.isOnGround()));
+        }
         MC.player.networkHandler.sendPacket(new ClientCommandC2SPacket(MC.player, ClientCommandC2SPacket.Mode.PRESS_SHIFT_KEY));
         MC.interactionManager.interactBlock(MC.player, MC.world, hand, new BlockHitResult(hitVec, side2, neighbor, false));
         MC.player.swingHand(hand);

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/WorldUtils.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/WorldUtils.java
@@ -110,9 +110,8 @@ public class WorldUtils implements Wrapper {
                 MC.player.pitch + MathHelper
                         .wrapDegrees(pitch - MC.player.pitch)};
 
-        if (rotate) {
-            MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(rotations[0], rotations[1], MC.player.isOnGround()));
-        }
+        if (rotate) MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.LookOnly(rotations[0], rotations[1], MC.player.isOnGround()));
+
         MC.player.networkHandler.sendPacket(new ClientCommandC2SPacket(MC.player, ClientCommandC2SPacket.Mode.PRESS_SHIFT_KEY));
         MC.interactionManager.interactBlock(MC.player, MC.world, hand, new BlockHitResult(hitVec, side2, neighbor, false));
         MC.player.swingHand(hand);

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/WorldUtils.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/utils/WorldUtils.java
@@ -357,4 +357,12 @@ public class WorldUtils implements Wrapper {
     public static boolean isBot(Entity entity) {
         return entity instanceof PlayerEntity && entity.isInvisibleTo(MC.player) && !entity.isOnGround() && !entity.collides();
     }
+
+    // must be done onTick - put this here because there may be other uses for fakeJump elsewhere, but it can just be put right into burrow if not.
+    public static void fakeJump() {
+        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionOnly(MC.player.getX(), MC.player.getY() + 0.40, MC.player.getZ(), true));
+        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionOnly(MC.player.getX(), MC.player.getY() + 0.75, MC.player.getZ(), true));
+        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionOnly(MC.player.getX(), MC.player.getY() + 1.00, MC.player.getZ(), true));
+        MC.player.networkHandler.sendPacket(new PlayerMoveC2SPacket.PositionOnly(MC.player.getX(), MC.player.getY() + 1.15, MC.player.getZ(), true));
+    }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
@@ -82,6 +82,7 @@ public class AresMod extends Ares {
                 // exploit
                 CoordTpExploit.class,
                 FastPlace.class,
+                InstantMine.class,
                 LiquidInteract.class,
                 MultiTask.class,
                 NewChunks.class,

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
@@ -134,6 +134,7 @@ public class AresMod extends Ares {
                 IceSpeed.class,
                 InventoryMove.class,
                 Jesus.class,
+                NoBlockPush.class,
                 NoClip.class,
                 NoSlowDown.class,
                 PacketFly.class,

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/movement/BlockPushEvent.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/movement/BlockPushEvent.java
@@ -1,0 +1,19 @@
+package dev.tigr.ares.forge.event.events.movement;
+
+import dev.tigr.simpleevents.event.Event;
+
+/**
+ * @author Makrennel
+ */
+public class BlockPushEvent extends Event {
+    public double var1;
+    public double var2;
+    public double var3;
+
+    public BlockPushEvent(double var1, double var2, double var3) {
+        this.setCancelled(false);
+        this.var1 = var1;
+        this.var2 = var2;
+        this.var3 = var3;
+    }
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Auto32k.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Auto32k.java
@@ -32,6 +32,7 @@ import net.minecraft.util.math.Vec3d;
 public class Auto32k extends Module {
     static final private TextColor COLOR = TextColor.BLUE;
     private final Setting<PlaceMode> mode = register(new EnumSetting<PlaceMode>("Mode", PlaceMode.DISPENSER));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Integer> placeDelay = register(new IntegerSetting("Disp.-Delay", 15, 0, 20));
     private final Setting<Boolean> SecrectClose = register(new BooleanSetting("SecretClose", false));
     private BlockPos basePos;
@@ -116,14 +117,14 @@ public class Auto32k extends Module {
             return false;
         }
 
-        hopper = InventoryUtils.findItem(Item.getItemById(154));
+        hopper = InventoryUtils.findItemInHotbar(Item.getItemById(154));
         if(hopper == -1) {
             UTILS.printMessage(COLOR + "A hopper was not found in your hotbar!");
             return false;
         }
 
         for(int i = 219; i <= 234; i++) {
-            shulker = InventoryUtils.findItem(Item.getItemById(i));
+            shulker = InventoryUtils.findItemInHotbar(Item.getItemById(i));
             if(shulker != -1) {
                 break;
             }
@@ -143,14 +144,14 @@ public class Auto32k extends Module {
             }
 
             //Check for dispenser in hotbar
-            dispenser = InventoryUtils.findItem(Item.getItemById(23));
+            dispenser = InventoryUtils.findItemInHotbar(Item.getItemById(23));
             if(dispenser == -1) {
                 UTILS.printMessage(COLOR + "No dispenser found in hotbar!");
                 return false;
             }
 
             //Check for redstone block in hopper
-            redstone = InventoryUtils.findItem(Item.getItemById(152));
+            redstone = InventoryUtils.findItemInHotbar(Item.getItemById(152));
             if(redstone == -1) {
                 UTILS.printMessage(COLOR + "No redstone block found in hotbar!");
                 return false;
@@ -183,11 +184,11 @@ public class Auto32k extends Module {
         if(mode.getValue() == PlaceMode.HOPPER_ONLY) {
             //Place hopper
             MC.player.inventory.currentItem = hopper;
-            WorldUtils.placeBlockMainHand(basePos);
+            WorldUtils.placeBlockMainHand(basePos, rotate.getValue());
 
             //Place shulker
             MC.player.inventory.currentItem = shulker;
-            WorldUtils.placeBlockMainHand(new BlockPos(basePos.getX(), basePos.getY() + 1, basePos.getZ()));
+            WorldUtils.placeBlockMainHand(new BlockPos(basePos.getX(), basePos.getY() + 1, basePos.getZ()), rotate.getValue());
 
             endSequence();
         } else if(mode.getValue() == PlaceMode.DISPENSER) {
@@ -217,7 +218,7 @@ public class Auto32k extends Module {
             }
             if(MC.world.getBlockState(block).getMaterial().isReplaceable()) {
                 MC.player.inventory.currentItem = solidBlock;
-                WorldUtils.placeBlockMainHand(block);
+                WorldUtils.placeBlockMainHand(block, rotate.getValue());
             }
             //End Place block
 
@@ -241,7 +242,7 @@ public class Auto32k extends Module {
             }
             if(MC.world.getBlockState(block).getMaterial().isReplaceable()) {
                 MC.player.inventory.currentItem = dispenser;
-                WorldUtils.placeBlockMainHand(block);
+                WorldUtils.placeBlockMainHand(block, rotate.getValue());
                 MC.player.inventory.currentItem = shulker;
                 MC.playerController.processRightClickBlock(MC.player, MC.world, block, EnumFacing.UP, new Vec3d(block.getX(), block.getY(), block.getZ()), EnumHand.MAIN_HAND);
                 tickCount++;
@@ -272,8 +273,8 @@ public class Auto32k extends Module {
                     block = new BlockPos(basePos.add(1, 2, 0));
             }
             if(MC.world.getBlockState(block).getMaterial().isReplaceable()) {
-                MC.player.inventory.currentItem = InventoryUtils.findItem(Item.getItemById(152));
-                WorldUtils.placeBlockMainHand(block);
+                MC.player.inventory.currentItem = InventoryUtils.findItemInHotbar(Item.getItemById(152));
+                WorldUtils.placeBlockMainHand(block, rotate.getValue());
                 tickCount++;
                 return;
             }
@@ -281,7 +282,7 @@ public class Auto32k extends Module {
 
             //Place hopper
             MC.player.inventory.currentItem = hopper;
-            WorldUtils.placeBlockMainHand(basePos);
+            WorldUtils.placeBlockMainHand(basePos, rotate.getValue());
 
             MC.player.inventory.currentItem = shulker;
 

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoCity.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoCity.java
@@ -4,6 +4,7 @@ import dev.tigr.ares.core.feature.FriendManager;
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
 import dev.tigr.ares.core.util.render.TextColor;
 import dev.tigr.ares.forge.utils.Comparators;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 @Module.Info(name = "AutoCity", description = "Automatically mines closest players surround", category = Category.COMBAT)
 public class AutoCity extends Module {
     private final Setting<Double> range = register(new DoubleSetting("Range", 5, 0, 10));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     
     @Override
     public void onEnable() {
@@ -64,8 +66,10 @@ public class AutoCity extends Module {
                     MC.player.connection.sendPacket(new CPacketHeldItemChange(index));
 
                     // rotate
-                    double[] rotations = WorldUtils.calculateLookAt(target.getX() + 0.5, target.getY() + 0.5, target.getZ() + 0.5, MC.player);
-                    MC.player.connection.sendPacket(new CPacketPlayer.Rotation((float) rotations[0], (float) rotations[1], MC.player.onGround));
+                    if (rotate.getValue()) {
+                        double[] rotations = WorldUtils.calculateLookAt(target.getX() + 0.5, target.getY() + 0.5, target.getZ() + 0.5, MC.player);
+                        MC.player.connection.sendPacket(new CPacketPlayer.Rotation((float) rotations[0], (float) rotations[1], MC.player.onGround));
+                    }
 
                     // break
                     MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, target, EnumFacing.UP));

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoCity.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoCity.java
@@ -31,6 +31,7 @@ public class AutoCity extends Module {
     private final Setting<Double> range = register(new DoubleSetting("Range", 5, 0, 10));
     private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Boolean> instant = register(new BooleanSetting("Instant", true));
+    private final Setting<Boolean> oneDotThirteen = register(new BooleanSetting("1.13+", false));
 
     private boolean toggleInstant = false;
     
@@ -54,8 +55,10 @@ public class AutoCity extends Module {
                 BlockPos target = null;
                 for(BlockPos block: blocks) {
                     if(!inPlayerCity(block) && MC.world.getBlockState(block).getBlock() != Blocks.BEDROCK && MC.player.getDistanceSq(block.getX() + 0.5, block.getY() + 0.5, block.getZ() + 0.5) < range.getValue() * range.getValue()) {
-                        target = block;
-                        break;
+                        if (oneDotThirteen.getValue() || MC.world.getBlockState(new BlockPos(block.getX(), block.getY() + 1, block.getZ())).getBlock() == Blocks.AIR) {
+                            target = block;
+                            break;
+                        }
                     }
                 }
                 if(target == null) continue;
@@ -83,7 +86,6 @@ public class AutoCity extends Module {
                     // break
                     MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, target, EnumFacing.UP));
                     MC.player.swingArm(EnumHand.MAIN_HAND);
-                    UTILS.printMessage(TextColor.BLUE + " X " + TextColor.GOLD + playerEntity.getPosition().getX() + TextColor.BLUE + " Y " + TextColor.GOLD + playerEntity.getPosition().getY() + TextColor.BLUE + " Z " + TextColor.GOLD + playerEntity.getPosition().getZ());
                     if (instant.getValue()) MC.playerController.onPlayerDamageBlock(new BlockPos(target.getX(), target.getY(), target.getZ()), EnumFacing.UP);
                     MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.STOP_DESTROY_BLOCK, target, EnumFacing.UP));
 

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoSurround.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoSurround.java
@@ -17,13 +17,16 @@ import net.minecraft.network.play.server.SPacketEntityStatus;
 @Module.Info(name = "AutoSurround", description = "Automatically enable surround in certain circumstances", category = Category.COMBAT)
 public class AutoSurround extends Module {
     private final Setting<Boolean> hole = register(new BooleanSetting("When in hole", true));
+    private final Setting<Boolean> holeSnap = register(new BooleanSetting("Hole Center", false)) .setVisibility(hole::getValue);
     private final Setting<Boolean> pop = register(new BooleanSetting("On totem pop", false));
+    private final Setting<Boolean> popSnap = register(new BooleanSetting("Totem Center", true)).setVisibility(pop::getValue);
     @EventHandler
     public EventListener<PacketEvent.Receive> packetReceiveEvent = new EventListener<>(event -> {
         if(MC.player != null && event.getPacket() instanceof SPacketEntityStatus && pop.getValue()) {
             SPacketEntityStatus status = (SPacketEntityStatus) event.getPacket();
             if(status.getOpCode() == 35 && status.getEntity(MC.world) == MC.player) {
                 Surround.INSTANCE.setEnabled(true);
+                Surround.toggleCenter(popSnap.getValue());
             }
         }
     });
@@ -32,6 +35,6 @@ public class AutoSurround extends Module {
     public void onTick() {
         if(WorldUtils.isHole(MC.player.getPosition()) != HoleType.NONE && !Surround.INSTANCE.getEnabled() && hole.getValue())
             Surround.INSTANCE.setEnabled(true);
-            Surround.toggleCenter(false);
+        Surround.toggleCenter(holeSnap.getValue());
     }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoTrap.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoTrap.java
@@ -4,6 +4,7 @@ import dev.tigr.ares.core.feature.FriendManager;
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.EnumSetting;
 import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
@@ -22,6 +23,7 @@ import net.minecraft.util.math.BlockPos;
 public class AutoTrap extends Module {
     private final Setting<Mode> mode = register(new EnumSetting<>("Mode", Mode.FULL));
     private final Setting<Double> range = register(new DoubleSetting("Range", 8.0D, 0.0D, 15.0D));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Integer> delay = register(new IntegerSetting("Delay", 2, 0, 10));
 
     @Override
@@ -45,7 +47,7 @@ public class AutoTrap extends Module {
                             int newSlot = InventoryUtils.findBlockInHotbar(Blocks.OBSIDIAN);
                             if(newSlot == -1) return;
                             else MC.player.inventory.currentItem = newSlot;
-                            WorldUtils.placeBlockMainHand(pos);
+                            WorldUtils.placeBlockMainHand(pos, rotate.getValue());
                             MC.player.inventory.currentItem = oldSlot;
                             return;
                         }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoTrap.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/AutoTrap.java
@@ -42,7 +42,7 @@ public class AutoTrap extends Module {
                         ) {
                             //place block
                             int oldSlot = MC.player.inventory.currentItem;
-                            int newSlot = InventoryUtils.findBlock(Blocks.OBSIDIAN);
+                            int newSlot = InventoryUtils.findBlockInHotbar(Blocks.OBSIDIAN);
                             if(newSlot == -1) return;
                             else MC.player.inventory.currentItem = newSlot;
                             WorldUtils.placeBlockMainHand(pos);

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Burrow.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Burrow.java
@@ -7,6 +7,7 @@ import dev.tigr.ares.core.setting.settings.*;
 import dev.tigr.ares.core.setting.settings.numerical.*;
 import dev.tigr.ares.core.util.global.ReflectionHelper;
 import dev.tigr.ares.core.util.render.TextColor;
+import dev.tigr.ares.forge.impl.modules.movement.NoBlockPush;
 import dev.tigr.ares.forge.utils.HoleType;
 import dev.tigr.ares.forge.utils.InventoryUtils;
 import dev.tigr.ares.forge.utils.WorldUtils;
@@ -22,66 +23,66 @@ import net.minecraft.util.math.BlockPos;
  */
 @Module.Info(name = "Burrow", description = "Places an obsidian block inside your feet", category = Category.COMBAT)
 public class Burrow extends Module {
-
-    private final Setting<Double> height = register(new DoubleSetting("Height", 1.12, 1.0, 1.3));
-    private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", true));
-    private final Setting<Boolean> autoReturn = register(new BooleanSetting("Auto Switch Return", true));
-    private final Setting<Boolean> holeOnly = register(new BooleanSetting("Hole Only", true));
+    private final Setting<Boolean> holeOnly = register(new BooleanSetting("Hole Only", false));
     private final Setting<Boolean> toggleSurround = register(new BooleanSetting("Toggle Surround On", false));
-    private final Setting<FastMode> fastMode = register(new EnumSetting<>("Fast Mode", FastMode.NONE));
-    private final Setting<Integer> timerModeTPS = register(new IntegerSetting("FastMode-TPS", 2500, 1, 30000));
-    private final Setting<CurrBlock> blockToUse = register(new EnumSetting<>("Block", CurrBlock.OBSIDIAN));
-    private final Setting<HoleBlock> holeBlock = register(new EnumSetting<>("In Hole", HoleBlock.OBSIDIAN));
-    private final Setting<BackBlock> backupBlock = register(new EnumSetting<>("Backup", BackBlock.ENDER_CHEST));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", false));
+    private final Setting<Boolean> preventBlockPush = register(new BooleanSetting("Prevent Block Push", true));
 
-    enum FastMode {NONE, TPS}
-    enum CurrBlock {OBSIDIAN, ENDER_CHEST, ENCHANTING_TABLE, ANVIL}
-    enum HoleBlock {OBSIDIAN, ENDER_CHEST, ENCHANTING_TABLE, ANVIL}
-    enum BackBlock {OBSIDIAN, ENDER_CHEST, ENCHANTING_TABLE, ANVIL}
+    private final Setting<Mode> setMode = register(new EnumSetting<>("Mode", Mode.Instant));
+    private final Setting<Integer> timerModeTimer = register(new IntegerSetting("FastMode-Timer", 2500, 1, 30000)).setVisibility(() -> setMode.getValue() == Mode.NormalTimer || setMode.getValue() == Mode.SemiInstantTimer);
+    private final Setting<Double> height = register(new DoubleSetting("Trigger Height", 1.12, 1.0, 1.3)).setVisibility(() -> setMode.getValue() != Mode.Instant);
+    private final Setting<Float> fakeClipHeight = register(new FloatSetting("Rubberband Height", 12, -60, 60)).setVisibility(() -> setMode.getValue() != Mode.NormalTimer || setMode.getValue() != Mode.Normal);;
+
+    private final Setting<CurrBlock> blockToUse = register(new EnumSetting<>("Block", CurrBlock.Obsidian));
+    private final Setting<CurrBlock> backupBlock = register(new EnumSetting<>("Backup", CurrBlock.EnderChest));
+
+    enum Mode {Normal, NormalTimer, SemiInstant, SemiInstantTimer, Instant}
+    enum CurrBlock {Obsidian, EnderChest, EnchantingTable, Anvil}
 
     private BlockPos playerPos;
-    private BlockPos airAbove;
-
-    private double jumpHeight;
 
     float oldYaw;
     float oldPitch;
 
+    int oldSelection = -1;
+
     //get the Block value of all three options selected
     private Block getCurrBlock(){
-        Block current = null;
-        if (blockToUse.getValue() == CurrBlock.OBSIDIAN) {current = Blocks.OBSIDIAN;}
-        else if (blockToUse.getValue() == CurrBlock.ENDER_CHEST) {current = Blocks.ENDER_CHEST;}
-        else if (blockToUse.getValue() == CurrBlock.ENCHANTING_TABLE) {current = Blocks.ENCHANTING_TABLE;}
-        else if (blockToUse.getValue() == CurrBlock.ANVIL) {current = Blocks.ANVIL;}
-        return current;
-    }
-    private Block getHoleBlock(){
-        Block hole = null;
-        if (holeBlock.getValue() == HoleBlock.OBSIDIAN) {hole = Blocks.OBSIDIAN;}
-        else if (holeBlock.getValue() == HoleBlock.ENDER_CHEST) {hole = Blocks.ENDER_CHEST;}
-        else if (holeBlock.getValue() == HoleBlock.ENCHANTING_TABLE) {hole = Blocks.ENCHANTING_TABLE;}
-        else if (holeBlock.getValue() == HoleBlock.ANVIL) {hole = Blocks.ANVIL;}
-        return hole;
+        Block index = null;
+        if (blockToUse.getValue() == CurrBlock.Obsidian) {index = Blocks.OBSIDIAN;}
+        else if (blockToUse.getValue() == CurrBlock.EnderChest) {index = Blocks.ENDER_CHEST;}
+        else if (blockToUse.getValue() == CurrBlock.EnchantingTable) {index = Blocks.ENCHANTING_TABLE;}
+        else if (blockToUse.getValue() == CurrBlock.Anvil) {index = Blocks.ANVIL;}
+        return index;
     }
     private Block getBackBlock(){
-        Block backup = null;
-        if (backupBlock.getValue() == BackBlock.OBSIDIAN) {backup = Blocks.OBSIDIAN;}
-        else if (backupBlock.getValue() == BackBlock.ENDER_CHEST) {backup = Blocks.ENDER_CHEST;}
-        else if (backupBlock.getValue() == BackBlock.ENCHANTING_TABLE) {backup = Blocks.ENCHANTING_TABLE;}
-        else if (backupBlock.getValue() == BackBlock.ANVIL) {backup = Blocks.ANVIL;}
-        return backup;
+        Block index = null;
+        if (backupBlock.getValue() == CurrBlock.Obsidian) {index = Blocks.OBSIDIAN;}
+        else if (backupBlock.getValue() == CurrBlock.EnderChest) {index = Blocks.ENDER_CHEST;}
+        else if (backupBlock.getValue() == CurrBlock.EnchantingTable) {index = Blocks.ENCHANTING_TABLE;}
+        else if (backupBlock.getValue() == CurrBlock.Anvil) {index = Blocks.ANVIL;}
+        return index;
+    }
+
+    private void switchToBlock() {
+        //main block
+        if (!(InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0)) {
+            oldSelection = MC.player.inventory.currentItem;
+            MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getCurrBlock());
+        }
+        //backup block to use when either is unavailable
+        else if (!(InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0)) {
+            oldSelection = MC.player.inventory.currentItem;
+            MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getBackBlock());
+        }
     }
 
     @Override
     public void onEnable() {
         playerPos = new BlockPos(MC.player.posX, MC.player.posY, MC.player.posZ);
-        double airAboveY = playerPos.getY() + 3;
-        airAbove = new BlockPos(playerPos.getX(), airAboveY, playerPos.getZ());
-        double eTableHeight = height.getValue() - 0.25;
 
         //determine if player is already burrowed
-        if (MC.world.getBlockState(playerPos).getBlock() == getCurrBlock() || MC.world.getBlockState(playerPos).getBlock() == getBackBlock() || MC.world.getBlockState(playerPos).getBlock() == getHoleBlock() || MC.world.getBlockState(playerPos).getBlock() == Blocks.ENCHANTING_TABLE) {
+        if (MC.world.getBlockState(playerPos).getBlock() == getCurrBlock() || MC.world.getBlockState(playerPos).getBlock() == getBackBlock()) {
             UTILS.printMessage(TextColor.BLUE + "Already Burrowed!");
             setEnabled(false);
             return;
@@ -94,24 +95,16 @@ public class Burrow extends Module {
             return;
         }
 
-        //checks there is enough space above player, and automatically changes height if not so enchanting table can be used if in hotbar.
-        if (MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
-            if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) > 0) {
-                jumpHeight = eTableHeight;
-            }
-            else if (InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) {
-                UTILS.printMessage(TextColor.RED + "Not enough space above!");
-                setEnabled(false);
-                return;
-            }
-        }
-        else jumpHeight = height.getValue();
-
         //checks that player has the blocks needed available
-        if (InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0 && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0 || InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0 && WorldUtils.isHole(MC.player.getPosition()) != HoleType.NONE && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0){
+        if (InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0 && InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0) {
             UTILS.printMessage(TextColor.RED + "No Burrow Blocks Found!");
             setEnabled(false);
             return;
+        }
+
+        //toggles on NoBurrowPush
+        if(preventBlockPush.getValue()) {
+            NoBlockPush.INSTANCE.setEnabled(true);
         }
 
         //toggles Surround with snap turned off (snap breaks burrow)
@@ -120,69 +113,65 @@ public class Burrow extends Module {
             Surround.toggleCenter(false);
         }
 
-        //jump
-        MC.player.jump();
+        //turns on Timer if Fast Mode is set to Timer
+        if (setMode.getValue() == Mode.SemiInstantTimer || setMode.getValue() == Mode.NormalTimer) {
+            ReflectionHelper.setPrivateValue(net.minecraft.util.Timer.class, ReflectionHelper.getPrivateValue(Minecraft.class, MC, "timer", "field_71428_T"), 1000.0F / timerModeTimer.getValue(), "tickLength", "field_194149_e");
+        }
+
+        //jump if not Instant mode
+        if (setMode.getValue() != Mode.Instant) {
+            MC.player.jump();
+        }
     }
     public void onTick() {
-        //turns on Timer if Fast Mode is set to TPS
-        if (fastMode.getValue() == FastMode.TPS) {
-            ReflectionHelper.setPrivateValue(net.minecraft.util.Timer.class, ReflectionHelper.getPrivateValue(Minecraft.class, MC, "timer", "field_71428_T"), 1000.0F / timerModeTPS.getValue(), "tickLength", "field_194149_e");
-        }
         //run the main sequence
         run();
     }
     public void onDisable() {
         //turns off Timer
-        if(fastMode.getValue() == FastMode.TPS) {
+        if(setMode.getValue() == Mode.SemiInstantTimer || setMode.getValue() == Mode.NormalTimer) {
             ReflectionHelper.setPrivateValue(net.minecraft.util.Timer.class, ReflectionHelper.getPrivateValue(Minecraft.class, MC, "timer", "field_71428_T"), 1000.0F / 20.0F, "tickLength", "field_194149_e");
         }
-        MC.player.connection.sendPacket(new CPacketPlayer.Rotation(oldYaw, oldPitch, MC.player.onGround));
+        if (rotate.getValue()) {
+            MC.player.connection.sendPacket(new CPacketPlayer.Rotation(oldYaw, oldPitch, MC.player.onGround));
+        }
     }
     public void run() {
         if (MC.player == null || MC.world == null) return;
 
-        int oldSelection = -1;
         oldYaw = MC.player.rotationYaw;
         oldPitch = MC.player.rotationPitch;
 
-        if (MC.player.posY > playerPos.getY() + jumpHeight) {
-            //main block to use
-            if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(Blocks.ENCHANTING_TABLE) <= 0) && MC.world.getBlockState(airAbove).getBlock() != Blocks.AIR) {
-                oldSelection = MC.player.inventory.currentItem;
-                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(Blocks.ENCHANTING_TABLE);
-            }
+        switchToBlock();
 
-            //block when in hole
-            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getHoleBlock()) <= 0) && WorldUtils.isHole(MC.player.getPosition()) != HoleType.NONE) {
-                oldSelection = MC.player.inventory.currentItem;
-                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getHoleBlock());
-            }
-
-            //main block
-            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getCurrBlock()) <= 0)) {
-                oldSelection = MC.player.inventory.currentItem;
-                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getCurrBlock());
-            }
-
-            //backup block to use when either is unavailable
-            else if (autoSwitch.getValue() && !(InventoryUtils.amountBlockInHotbar(getBackBlock()) <= 0)) {
-                oldSelection = MC.player.inventory.currentItem;
-                MC.player.inventory.currentItem = InventoryUtils.findBlockInHotbar(getBackBlock());
-            }
-
-            //place block where the player was before jumping
-            WorldUtils.placeBlockMainHand(playerPos);
-
-            //switches back to initial item held if both Auto Switch and Auto Switch Return are true
-            if (autoSwitch.getValue() && autoReturn.getValue()) {
-                MC.player.inventory.currentItem = oldSelection;
-            }
-
-            //jumps again to snap down if FastMode is not TPS
-            MC.player.jump();
-
-            //disable module
-            setEnabled(false);
+        if (setMode.getValue() == Mode.Instant) {
+            WorldUtils.fakeJump();
+            runSequence();
         }
+
+        if (setMode.getValue() != Mode.Instant) {
+            if (MC.player.posY >= playerPos.getY() + height.getValue()) {
+                runSequence();
+            }
+        }
+    }
+
+    private void runSequence(){
+        //place block where the player was before jumping
+        if (MC.player.inventory.currentItem == -1) {
+            setEnabled(false);
+        } else WorldUtils.placeBlockMainHand(playerPos, rotate.getValue(), true);
+
+
+        //switches back to initial item held if both Auto Switch and Auto Switch Return are true
+        MC.player.inventory.currentItem = oldSelection;
+
+        //tries to produce a rubberband
+        if (setMode.getValue() == Mode.Instant || setMode.getValue() == Mode.SemiInstant || setMode.getValue() == Mode.SemiInstantTimer) {
+            MC.player.connection.sendPacket(new CPacketPlayer.Position(MC.player.posX, MC.player.posY + fakeClipHeight.getValue(), MC.player.posZ, false));
+        } else MC.player.jump();
+
+        //disable module
+        setEnabled(false);
     }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/CrystalAura.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/CrystalAura.java
@@ -73,11 +73,18 @@ public class CrystalAura extends Module {
     private final Setting<Rotations> rotateMode = register(new EnumSetting<>("Rotations", Rotations.PACKET));
     private final Setting<Canceller> cancelMode = register(new EnumSetting<>("Cancel", Canceller.NO_DESYNC));
 
+    private final Setting<Boolean> showColorSettings = register(new BooleanSetting("Color Settings", false));
+    private final Setting<Integer> colorRed = register(new IntegerSetting("Red", 237, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorGreen = register(new IntegerSetting("Green", 0, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorBlue = register(new IntegerSetting("Blue", 0, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> fillAlpha = register(new IntegerSetting("Fill Alpha", 30, 0, 100)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> boxAlpha = register(new IntegerSetting("Box Alpha", 69, 0, 100)).setVisibility(showColorSettings::getValue);
+
     enum Mode { DAMAGE, DISTANCE }
     enum Order { PLACE_BREAK, BREAK_PLACE }
     enum Target { CLOSEST, MOST_DAMAGE }
     enum Rotations { PACKET, REAL, NONE }
-    enum Canceller { NO_DESYNC, ON_HIT, ON_SOUND }
+    enum Canceller { NO_DESYNC, ON_HIT, ON_PACKET }
 
     private long renderTimer = -1;
     private long placeTimer = -1;
@@ -256,10 +263,17 @@ public class CrystalAura extends Module {
     @Override
     public void onRender3d() {
         if(target != null) {
+            float red = (float)colorRed.getValue() / 255;
+            float green = (float)colorGreen.getValue() / 255;
+            float blue = (float)colorBlue.getValue() / 255;
+            float fAlpha = (float)fillAlpha.getValue() / 100;
+            float bAlpha = (float)boxAlpha.getValue() / 100;
             RenderUtils.prepare3d();
             AxisAlignedBB bb = RenderUtils.getBoundingBox(target);
-            RenderGlobal.renderFilledBox(bb, 0.93f, 0, 0, 0.2f);
-            RenderGlobal.drawSelectionBoundingBox(bb, 0.55f, 0, 0, 0.2f);
+            if(bb != null) {
+                RenderGlobal.renderFilledBox(bb, red, green, blue, fAlpha);
+                RenderGlobal.drawSelectionBoundingBox(bb, red, green, blue, bAlpha);
+            }
             RenderUtils.end3d();
         }
     }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/HoleFiller.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/HoleFiller.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 @Module.Info(name = "HoleFiller", description = "Automatically fills nearby holes", category = Category.COMBAT)
 public class HoleFiller extends Module {
     private final Setting<Boolean> skipNearby = register(new BooleanSetting("Skip closest", true));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Double> range = register(new DoubleSetting("Range", 5, 0, 10));
 
     @Override
@@ -56,7 +57,7 @@ public class HoleFiller extends Module {
                 if(slot != -1) MC.player.inventory.currentItem = slot;
                 else return;
 
-                WorldUtils.placeBlockMainHand(hole);
+                WorldUtils.placeBlockMainHand(hole, rotate.getValue());
                 MC.player.inventory.currentItem = first;
                 return;
             }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/HopperAura.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/HopperAura.java
@@ -53,7 +53,7 @@ public class HopperAura extends Module {
 
                 if(MC.player.getDistance(hopperPos.getX(), hopperPos.getY(), hopperPos.getZ()) <= distance.getValue()) {
                     for(int x: picks) {
-                        int slot = InventoryUtils.findItem(Item.getItemById(x));
+                        int slot = InventoryUtils.findItemInHotbar(Item.getItemById(x));
                         if(slot != -1) {
                             MC.player.inventory.currentItem = slot;
 

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Surround.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Surround.java
@@ -26,6 +26,7 @@ public class Surround extends Module {
 
     private final Setting<Boolean> snap = register(new BooleanSetting("Center", true));
     private final Setting<Integer> delay = register(new IntegerSetting("Delay", 0, 0, 10));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Boolean> air = register(new BooleanSetting("Air-place", false));
     private BlockPos lastPos = new BlockPos(0, -100, 0);
     private int ticks = 0;
@@ -59,7 +60,7 @@ public class Surround extends Module {
         if(needsToPlace()) {
             for(BlockPos pos: getPositions()) {
                 MC.player.inventory.currentItem = obbyIndex;
-                if(WorldUtils.placeBlockMainHand(pos) && delay.getValue() != 0) return;
+                if(WorldUtils.placeBlockMainHand(pos, rotate.getValue()) && delay.getValue() != 0) return;
             }
 
             MC.player.inventory.currentItem = prevSlot;

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Surround.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/combat/Surround.java
@@ -126,5 +126,6 @@ public class Surround extends Module {
     @Override
     public void onDisable() {
         ticks = 0;
+        doSnap = true;
     }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/exploit/InstantMine.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/exploit/InstantMine.java
@@ -38,7 +38,7 @@ public class InstantMine extends Module {
 
     private final Setting<Boolean> repeatMine = register(new BooleanSetting("Repeat", true));
     private final Setting<Double> repeatRange = register(new DoubleSetting("Repeat Range", 5, 0, 10)).setVisibility(repeatMine::getValue);
-    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 120, 0, 1200));
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay(ms)", 120, 0, 1200));
     private final Setting<Boolean> pickOnly = register(new BooleanSetting("Only Pickaxe", true));
     private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", false)).setVisibility(pickOnly::getValue);
     private final Setting<Swing> swingType = register(new EnumSetting<>("Swing", Swing.Real));

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/exploit/InstantMine.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/exploit/InstantMine.java
@@ -1,0 +1,149 @@
+package dev.tigr.ares.forge.impl.modules.exploit;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
+import dev.tigr.ares.core.setting.settings.EnumSetting;
+import dev.tigr.ares.core.setting.settings.numerical.DoubleSetting;
+import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
+import dev.tigr.ares.core.util.global.ReflectionHelper;
+import dev.tigr.ares.forge.event.events.player.DamageBlockEvent;
+import dev.tigr.ares.forge.event.events.player.PacketEvent;
+import dev.tigr.ares.forge.utils.InventoryUtils;
+import dev.tigr.ares.forge.utils.RenderUtils;
+import dev.tigr.ares.forge.utils.Timer;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.multiplayer.PlayerControllerMP;
+import net.minecraft.client.renderer.RenderGlobal;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemPickaxe;
+import net.minecraft.network.Packet;
+import net.minecraft.network.play.client.CPacketAnimation;
+import net.minecraft.network.play.client.CPacketPlayerDigging;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+
+/**
+ * @author Makrennel
+ * Credit to Kami147 for the module off which this was based.
+ */
+@Module.Info(name = "InstantMine", description = "Instantly mines blocks after packet mining the first one.", category = Category.EXPLOIT)
+public class InstantMine extends Module {
+    public static InstantMine INSTANCE;
+
+    private final Setting<Boolean> repeatMine = register(new BooleanSetting("Repeat", true));
+    private final Setting<Double> repeatRange = register(new DoubleSetting("Repeat Range", 5, 0, 10)).setVisibility(repeatMine::getValue);
+    private final Setting<Integer> delay = register(new IntegerSetting("Delay", 120, 0, 1200));
+    private final Setting<Boolean> pickOnly = register(new BooleanSetting("Only Pickaxe", true));
+    private final Setting<Boolean> autoSwitch = register(new BooleanSetting("Auto Switch", false)).setVisibility(pickOnly::getValue);
+    private final Setting<Swing> swingType = register(new EnumSetting<>("Swing", Swing.Real));
+
+    private final Setting<Boolean> showColorSettings = register(new BooleanSetting("Color Settings", false));
+    private final Setting<Integer> colorRed = register(new IntegerSetting("Red", 255, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorGreen = register(new IntegerSetting("Green", 255, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> colorBlue = register(new IntegerSetting("Blue", 120, 0, 255)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> fillAlpha = register(new IntegerSetting("Fill Alpha", 24, 0, 100)).setVisibility(showColorSettings::getValue);
+    private final Setting<Integer> boxAlpha = register(new IntegerSetting("Box Alpha", 71, 0, 100)).setVisibility(showColorSettings::getValue);
+
+    enum Swing { None, Real, Packet }
+
+    private Timer repeatTimer = new Timer();
+    private BlockPos last;
+    private BlockPos render;
+    private boolean cancel = false;
+    private EnumFacing direction;
+
+    public InstantMine() {
+        INSTANCE = this;
+    }
+
+    private boolean shouldRepeat = true;
+    public void setShouldRepeat(Boolean shouldRepeat) {
+        INSTANCE.shouldRepeat = shouldRepeat;
+    }
+
+    @EventHandler
+    private EventListener<DamageBlockEvent> damageBlockEvent = new EventListener<>(event -> {
+       if (canBreakBlock(event.getBlockPos())) {
+           if(last == null || event.getBlockPos() != last) {
+               cancel = false;
+               if (swingType.getValue() == Swing.Packet) MC.player.connection.sendPacket(new CPacketAnimation(EnumHand.MAIN_HAND));
+               else if (swingType.getValue() == Swing.Real) MC.player.swingArm(EnumHand.MAIN_HAND);
+               MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, event.getBlockPos(), event.getEnumFacing()));
+               cancel = true;
+           } else {
+               if (swingType.getValue() == Swing.Packet) MC.player.connection.sendPacket(new CPacketAnimation(EnumHand.MAIN_HAND));
+               else if (swingType.getValue() == Swing.Real) MC.player.swingArm(EnumHand.MAIN_HAND);
+               MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, event.getBlockPos(), event.getEnumFacing()));
+               cancel = true;
+           }
+           MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.STOP_DESTROY_BLOCK, event.getBlockPos(), event.getEnumFacing()));
+
+           render = event.getBlockPos();
+           last = event.getBlockPos();
+           direction = event.getEnumFacing();
+
+           event.setCancelled(true);
+       }
+    });
+
+    @EventHandler
+    private EventListener<PacketEvent.Sent> onPacketSent = new EventListener<>(event -> {
+        Packet packet = event.getPacket();
+        if (packet instanceof CPacketPlayerDigging) {
+            CPacketPlayerDigging digPacket = (CPacketPlayerDigging) packet;
+            if(((CPacketPlayerDigging) packet).getAction() == CPacketPlayerDigging.Action.START_DESTROY_BLOCK && cancel) event.setCancelled(true);
+        }
+    });
+
+    @Override
+    public void onTick() {
+        if (MC.player.getDistance(render.getX(), render.getY(), render.getZ()) > repeatRange.getValue())
+            render = null;
+        else if (MC.player.getDistance(last.getX(), last.getY(), last.getZ()) <= repeatRange.getValue() && render == null)
+            render = last;
+        if (render != null && !MC.world.getBlockState(render).getMaterial().isReplaceable()) {
+            if (repeatMine.getValue() && repeatTimer.passedMillis(delay.getValue())) {
+                if (pickOnly.getValue() && !(MC.player.getHeldItem(EnumHand.MAIN_HAND).getItem() instanceof ItemPickaxe)) {
+                    if (autoSwitch.getValue()) {
+                        int newSelection = InventoryUtils.findItemInHotbar(Items.DIAMOND_PICKAXE);
+                        if (newSelection != -1) MC.player.inventory.currentItem = newSelection;
+                        else return;
+                    } else return;
+                }
+                MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.START_DESTROY_BLOCK, render, direction));
+                if (swingType.getValue() == Swing.Packet) MC.player.connection.sendPacket(new CPacketAnimation(EnumHand.MAIN_HAND));
+                else if (swingType.getValue() == Swing.Real) MC.player.swingArm(EnumHand.MAIN_HAND);
+                MC.player.connection.sendPacket(new CPacketPlayerDigging(CPacketPlayerDigging.Action.STOP_DESTROY_BLOCK, render, direction));
+                repeatTimer.reset();
+            }
+        }
+        ReflectionHelper.setPrivateValue(PlayerControllerMP.class, MC.playerController, 0, "blockHitDelay", "field_78781_i");
+    }
+
+    private boolean canBreakBlock(BlockPos blockPos) {
+        final IBlockState blockState = MC.world.getBlockState(blockPos);
+        return blockState.getBlockHardness(MC.world, blockPos) != -1;
+    }
+
+    @Override
+    public void onRender3d() {
+        float red = (float)colorRed.getValue() / 255;
+        float green = (float)colorGreen.getValue() / 255;
+        float blue = (float)colorBlue.getValue() / 255;
+        float fAlpha = (float)fillAlpha.getValue() / 100;
+        float bAlpha = (float)boxAlpha.getValue() / 100;
+        if(this.render != null) {
+            RenderUtils.prepare3d();
+            AxisAlignedBB bb = RenderUtils.getBoundingBox(this.render);
+            RenderGlobal.renderFilledBox(bb, red, green, blue, fAlpha);
+            RenderGlobal.drawSelectionBoundingBox(bb, red, green, blue, bAlpha);
+            RenderUtils.end3d();
+        }
+    }
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/movement/NoBlockPush.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/movement/NoBlockPush.java
@@ -1,0 +1,25 @@
+package dev.tigr.ares.forge.impl.modules.movement;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.forge.event.events.movement.BlockPushEvent;
+import dev.tigr.simpleevents.listener.EventHandler;
+import dev.tigr.simpleevents.listener.EventListener;
+
+/**
+ * @author Makrennel
+ * This is seperated from burrow because burrow toggles off after use.
+ */
+@Module.Info(name = "NoBlockPush", description = "Prevents full blocks from pushing you out (eg. When burrowed).", category = Category.MOVEMENT)
+public class NoBlockPush extends Module {
+    public static NoBlockPush INSTANCE;
+
+    public NoBlockPush() {
+        INSTANCE = this;
+    }
+
+    @EventHandler
+    public EventListener<BlockPushEvent> onBurrowPush = new EventListener<>(event -> {
+        event.setCancelled(true);
+    });
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/player/Scaffold.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/player/Scaffold.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 @Module.Info(name = "Scaffold", description = "Automatically bridges for you", category = Category.PLAYER)
 public class Scaffold extends Module {
     private final Setting<Integer> radius = register(new IntegerSetting("Radius", 0, 0, 2));
+    private final Setting<Boolean> rotate = register(new BooleanSetting("Rotate", true));
     private final Setting<Boolean> down = register(new BooleanSetting("Down", false));
     @EventHandler
     public EventListener<WalkOffLedgeEvent> walkOffLedgeEvent = new EventListener<>(event -> {
@@ -66,7 +67,7 @@ public class Scaffold extends Module {
 
             BlockPos under = new BlockPos(MC.player.posX, MC.player.posY - 2, MC.player.posZ);
 
-            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under);
+            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under, rotate.getValue());
 
             MC.player.inventory.currentItem = oldSlot;
 
@@ -77,7 +78,7 @@ public class Scaffold extends Module {
         if(radius.getValue() == 0) {
             BlockPos under = new BlockPos(MC.player.posX, MC.player.posY - 1, MC.player.posZ);
 
-            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under);
+            if(MC.world.getBlockState(under).getMaterial().isReplaceable()) WorldUtils.placeBlockMainHand(under, rotate.getValue());
 
             MC.player.inventory.currentItem = oldSlot;
 
@@ -94,7 +95,7 @@ public class Scaffold extends Module {
 
         for(BlockPos x: blocks) {
             if(MC.world.getBlockState(x).getMaterial().isReplaceable()) {
-                WorldUtils.placeBlockMainHand(x);
+                WorldUtils.placeBlockMainHand(x, rotate.getValue());
                 break;
             }
         }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/mixin/client/MixinEntityPlayerSP.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/mixin/client/MixinEntityPlayerSP.java
@@ -4,6 +4,7 @@ import com.mojang.authlib.GameProfile;
 import dev.tigr.ares.core.Ares;
 import dev.tigr.ares.core.event.render.PortalChatEvent;
 import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.forge.event.events.movement.BlockPushEvent;
 import dev.tigr.ares.forge.event.events.movement.MovePlayerEvent;
 import dev.tigr.ares.forge.event.events.player.PlayerDismountEvent;
 import net.minecraft.client.Minecraft;
@@ -20,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 /**
@@ -44,6 +46,12 @@ public abstract class MixinEntityPlayerSP extends AbstractClientPlayer {
     public void movePlayer(AbstractClientPlayer abstractClientPlayer, MoverType type, double x, double y, double z) {
         MovePlayerEvent event = Ares.EVENT_MANAGER.post(new MovePlayerEvent(type, x, y, z));
         if(!event.isCancelled()) super.move(type, event.getX(), event.getY(), event.getZ());
+    }
+
+    @Inject(method = "pushOutOfBlocks", at = @At("HEAD"), cancellable = true)
+    public void noPushOutOfBlocks(double var1, double var2, double var3, CallbackInfoReturnable ci) {
+        BlockPushEvent blockPushEvent = Ares.EVENT_MANAGER.post((new BlockPushEvent(var1, var2, var3)));
+        if (Ares.EVENT_MANAGER.post(new BlockPushEvent(var1, var2, var3)).isCancelled()) ci.cancel();
     }
 
     @Redirect(method = "onLivingUpdate", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/entity/EntityPlayerSP;closeScreen()V"))

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/utils/Timer.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/utils/Timer.java
@@ -1,0 +1,73 @@
+package dev.tigr.ares.forge.utils;
+
+/**
+ * @author Makrennel
+ */
+
+public class Timer {
+
+    private long nanoTime = -1L;
+
+    public void reset() {
+        nanoTime = System.nanoTime();
+    }
+
+    // All setters
+    public void setTicks(long ticks) { nanoTime = System.nanoTime() - convertTicksToNano(ticks); }
+
+    public void setNano(long time) { nanoTime = System.nanoTime() - time; }
+
+    public void setMicro(long time) { nanoTime = System.nanoTime() - convertMicroToNano(time); }
+
+    public void setMillis(long time) { nanoTime = System.nanoTime() - convertMillisToNano(time); }
+
+    public void setSec(long time) { nanoTime = System.nanoTime() - convertSecToNano(time); }
+
+    // All getters
+    public long getTicks() { return convertNanoToTicks(nanoTime); }
+
+    public long getNano() { return nanoTime; }
+
+    public long getMicro() { return convertNanoToMicro(nanoTime); }
+
+    public long getMillis() { return convertNanoToMillis(nanoTime); }
+
+    public long getSec() { return convertNanoToSec(nanoTime); }
+
+    // All passed
+    public boolean passedTicks(long ticks) { return passedNano(convertTicksToNano(ticks)); }
+
+    public boolean passedNano(long time) { return System.nanoTime() - nanoTime >= time; }
+
+    public boolean passedMicro(long time) { return passedNano(convertMicroToNano(time)); }
+
+    public boolean passedMillis(long time) { return passedNano(convertMillisToNano(time)); }
+
+    public boolean passedSec(long time) { return passedNano(convertSecToNano(time)); }
+
+    // Tick Conversions
+    public long convertMillisToTicks(long time) { return time / 50; }
+    public long convertTicksToMillis(long ticks) { return ticks * 50; }
+    public long convertNanoToTicks(long time) { return convertMillisToTicks(convertNanoToMillis(time)); }
+    public long convertTicksToNano(long ticks) { return convertMillisToNano(convertTicksToMillis(ticks)); }
+
+    // All Conversions To Smaller
+    public long convertSecToMillis(long time) { return time * 1000L; }
+    public long convertSecToMicro(long time) { return convertMillisToMicro(convertSecToMillis(time)); }
+    public long convertSecToNano(long time) { return convertMicroToNano(convertMillisToMicro(convertSecToMillis(time))); }
+
+    public long convertMillisToMicro(long time) { return time * 1000L; }
+    public long convertMillisToNano(long time) { return convertMicroToNano(convertMillisToMicro(time)); }
+
+    public long convertMicroToNano(long time) { return time * 1000L; }
+
+    // All Conversions To Larger
+    public long convertNanoToMicro(long time) { return time / 1000L; }
+    public long convertNanoToMillis(long time) { return convertMicroToMillis(convertNanoToMicro(time)); }
+    public long convertNanoToSec(long time) { return convertMillisToSec(convertMicroToMillis(convertNanoToMicro(time))); }
+
+    public long convertMicroToMillis(long time) { return time / 1000L; }
+    public long convertMicroToSec(long time) { return convertMillisToSec(convertMicroToMillis(time)); }
+
+    public long convertMillisToSec(long time) { return time / 1000L; }
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/utils/WorldUtils.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/utils/WorldUtils.java
@@ -1,6 +1,7 @@
 package dev.tigr.ares.forge.utils;
 
 import dev.tigr.ares.core.feature.FriendManager;
+import dev.tigr.ares.core.util.render.TextColor;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityAgeable;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static dev.tigr.ares.CoreWrapper.UTILS;
 import static dev.tigr.ares.Wrapper.MC;
 
 /**
@@ -45,6 +47,10 @@ public class WorldUtils {
         return placeBlock(EnumHand.MAIN_HAND, pos, rotate, ignoreEntity);
     }
 
+    public static boolean placeBlockNoRotate(EnumHand hand, BlockPos pos) {
+        return placeBlock(hand, pos, false, false);
+    }
+
     public static boolean placeBlock(EnumHand hand, BlockPos pos) {
         placeBlock(hand, pos, true, false);
         return true;
@@ -56,14 +62,16 @@ public class WorldUtils {
     public static boolean placeBlock(EnumHand hand, BlockPos pos, Boolean rotate, Boolean ignoreEntity) {
         // make sure place is empty if ignoreEntity is not true
         if(ignoreEntity) {
-            if (!MC.world.getBlockState(pos).getMaterial().isReplaceable())
+            if (!MC.world.getBlockState(pos).getMaterial().isReplaceable()) {
+                UTILS.printMessage(TextColor.GOLD + "NOT STUCK");
                 return false;
-        } else {
-            if (!MC.world.getBlockState(pos).getMaterial().isReplaceable() ||
-                    !MC.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos))
-                            .stream().noneMatch(Entity::canBeCollidedWith))
-                return false;
-        }
+            }
+        } else if (!MC.world.getBlockState(pos).getMaterial().isReplaceable() ||
+                    !MC.world.getEntitiesWithinAABBExcludingEntity(null, new AxisAlignedBB(pos)).stream().noneMatch(Entity::canBeCollidedWith)) {
+            UTILS.printMessage(TextColor.GOLD + "STUCK");
+            return false;
+            }
+
 
         Vec3d eyesPos = new Vec3d(MC.player.posX,
                 MC.player.posY + MC.player.getEyeHeight(),
@@ -333,5 +341,17 @@ public class WorldUtils {
 
     public static boolean isBot(Entity entity) {
         return entity instanceof EntityPlayer && entity.isInvisibleToPlayer(MC.player) && !entity.onGround && entity.isAirBorne && !entity.canBeCollidedWith();
+    }
+
+    // must be done onTick - put this here because there may be other uses for fakeJump elsewhere, but it can just be put right into burrow if not.
+    public static void fakeJump() {
+        MC.player.connection.sendPacket(new CPacketPlayer.Position(MC.player.posX, MC.player.posY + 0.40, MC.player.posZ, true));
+        UTILS.printMessage(TextColor.GOLD + "ONE");
+        MC.player.connection.sendPacket(new CPacketPlayer.Position(MC.player.posX, MC.player.posY + 0.75, MC.player.posZ, true));
+        UTILS.printMessage(TextColor.GOLD + "TWO");
+        MC.player.connection.sendPacket(new CPacketPlayer.Position(MC.player.posX, MC.player.posY + 1.00, MC.player.posZ, true));
+        UTILS.printMessage(TextColor.GOLD + "THREE");
+        MC.player.connection.sendPacket(new CPacketPlayer.Position(MC.player.posX, MC.player.posY + 1.15, MC.player.posZ, true));
+        UTILS.printMessage(TextColor.GOLD + "FOUR");
     }
 }


### PR DESCRIPTION
**Fixes #.**
AutoTrap/Auto32k invalid hotbar.
Forge Autocity mining block targeting blocks one block over if the player was more than halfway across the block. (I don't know if the same problem exists on Fabric because of lacking of Fakeplayer)
Surround Centering on Fabric.

**Changes proposed in this pull request:**
Added Instant Burrow (FakeJump) 
Added NoBlockPush which prevents Full Block Burrow from pushing you out.
Added InstantMine - based on Kami147's with some improvements.
Added a Timer Util that can be used in any module to create new timers using system nanotime as the basis.
Added AutoTrap modes and put AutoTrap on a millisecond timer to allow more fine-tuning by the player.
Made AutoCity compatible with InstantMine (toggleable)
Made a 1.13+ mode toggle for AutoCity which, when turned off, checks if the block above is also air, and if not cycles around to next block to check as normal.
Added a toggle for rotate to a bunch of modules for servers where rotations are not required. - see Additional Context
Added Firework aura to fabric for the person who kept asking (tested on Forge, because Fabric fakeplayer is currently not working, but removed the Forge version because it's not useful on 1.12).
Added temporary color settings to CrystalAura, hidden with a setVisibility and a boolean until something better is figured out for the people who wanted to change render color. Default is similar to old values, but with more alpha.
Added some options to placeBlock in the WorldUtils, and made placeBlockNoRotate return placeBlock with the options for code reuse because it was mostly the same.
Made CrystalAura show the name of the player it is targeting in the ModuleList


**Additional context**
Rotations - the rotations currently used by Ares aren't really sufficient for servers which require rotations. Quite often these servers use anticheats like NCP which rubberband the player for rotating too quickly as part of the fly check when placing/breaking a block. For example right now Ares is sending look packets right before placing something or attacking something, but the rotation resets immediately. This means modules like scaffold are looking up and down / back and forth extremely quickly rather than holding a looking position, causing rubberbanding on servers like 2b. Also on stricter servers in combat (for example attacking crystals / players) it'll rubberband the player if they rotate too quickly in a given period of time. While on some servers you can just use Fake rotations to circumvent these problems, on stricter servers this tends to be patched (as on 2b).

That's why, for use on servers which have anticheats but specifically disabled rotation checks to alleviate the fly check problem i have added rotate toggles to most of the modules. For the stricter servers a proper rotations management system will need to be figured out.