### PR TITLE
Added Tower to scaffold

### DIFF
--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/movement/PlayerJumpEvent.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/event/movement/PlayerJumpEvent.java
@@ -1,0 +1,6 @@
+package dev.tigr.ares.fabric.event.movement;
+
+import dev.tigr.simpleevents.event.Event;
+
+public class PlayerJumpEvent extends Event {
+}

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerEntity.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/mixin/client/MixinClientPlayerEntity.java
@@ -5,10 +5,7 @@ import dev.tigr.ares.core.Ares;
 import dev.tigr.ares.core.event.render.PortalChatEvent;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.util.global.ReflectionHelper;
-import dev.tigr.ares.fabric.event.movement.BlockPushEvent;
-import dev.tigr.ares.fabric.event.movement.EntityClipEvent;
-import dev.tigr.ares.fabric.event.movement.MovePlayerEvent;
-import dev.tigr.ares.fabric.event.movement.SlowDownEvent;
+import dev.tigr.ares.fabric.event.movement.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -73,4 +70,13 @@ public class MixinClientPlayerEntity extends AbstractClientPlayerEntity {
 //        MovePlayerEvent event = Ares.EVENT_MANAGER.post(new MovePlayerEvent(type, movement.x, movement.y, movement.z));
 //        if(!event.isCancelled()) super.move(type, new Vec3d(event.getX(), event.getY(), event.getZ()));
 //    }
+
+    @Override
+    public void jump() {
+        PlayerJumpEvent event = new PlayerJumpEvent();
+        Ares.EVENT_MANAGER.post(event);
+        if(!event.isCancelled()) {
+            super.jump();
+        }
+    }
 }

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/movement/PlayerJumpEvent.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/event/events/movement/PlayerJumpEvent.java
@@ -1,0 +1,6 @@
+package dev.tigr.ares.forge.event.events.movement;
+
+import dev.tigr.simpleevents.event.Event;
+
+public class PlayerJumpEvent extends Event {
+}

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/mixin/client/MixinEntityPlayerSP.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/mixin/client/MixinEntityPlayerSP.java
@@ -6,6 +6,7 @@ import dev.tigr.ares.core.event.render.PortalChatEvent;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.forge.event.events.movement.BlockPushEvent;
 import dev.tigr.ares.forge.event.events.movement.MovePlayerEvent;
+import dev.tigr.ares.forge.event.events.movement.PlayerJumpEvent;
 import dev.tigr.ares.forge.event.events.player.PlayerDismountEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
@@ -72,5 +73,14 @@ public abstract class MixinEntityPlayerSP extends AbstractClientPlayer {
     @Inject(method = "dismountRidingEntity", at = @At("RETURN"))
     public void onDismountEnd(CallbackInfo ci) {
         Ares.EVENT_MANAGER.post(new PlayerDismountEvent.End());
+    }
+
+    @Override
+    public void jump() {
+        PlayerJumpEvent event = new PlayerJumpEvent();
+        Ares.EVENT_MANAGER.post(event);
+        if(!event.isCancelled()) {
+            super.jump();
+        }
     }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
Added Tower to scaffold using fakejump and position updates. This works alright on some NCP servers, depending on the delay config / the server config. There's definitely better ways to do tower for NCP but I figured this out by accident while messing around with burrow and just decided to make it a thing because it's incredibly simple. If a better NCP tower is added this could be kept as another mode because it's generally faster than most NCP towers on non anticheat servers.