### PR TITLE
implemented minecarts count with the minimum trigger

### DIFF
--- a/ares-fabric-1.16/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric-1.16/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -77,6 +77,7 @@ public class AresMod extends Ares {
                 // hud
                 Armor.class,
                 ChestCount.class,
+                MinecartCount.class,
                 Coordinates.class,
                 CrystalCount.class,
                 ModuleList.class,

--- a/ares-fabric-1.16/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-fabric-1.16/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
@@ -24,7 +24,7 @@ public class MinecartCount extends HudElement {
             = register(new IntegerSetting("Min count ", 1, 1, 20));
 
     public MinecartCount() {
-        super(100, 60, 0, FONT_RENDERER.getFontHeight());
+        super(100, 60, 0, 5);
     }
 
     public void draw() {

--- a/ares-fabric-1.16/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-fabric-1.16/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
@@ -1,4 +1,4 @@
-package dev.tigr.ares.forge.impl.modules.hud.elements;
+package dev.tigr.ares.fabric.impl.modules.hud.elements;
 
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
@@ -7,8 +7,10 @@ import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
 import dev.tigr.ares.core.util.render.Color;
 import dev.tigr.ares.core.util.render.IRenderer;
-import dev.tigr.ares.forge.impl.modules.hud.HudElement;
-import net.minecraft.entity.item.EntityMinecartChest;
+import dev.tigr.ares.fabric.impl.modules.hud.HudElement;
+import net.minecraft.entity.vehicle.ChestMinecartEntity;
+
+import java.util.stream.StreamSupport;
 
 /**
  * @author UberRipper
@@ -26,8 +28,8 @@ public class MinecartCount extends HudElement {
     }
 
     public void draw() {
-        final int chests = (int) MC.world.loadedEntityList.stream()
-                .filter(Entity -> Entity instanceof EntityMinecartChest).count();
+        int chests = (int) StreamSupport.stream(MC.world.getEntities().spliterator(),false).
+                filter(entity -> entity instanceof ChestMinecartEntity).count();
         if (minimumNotificationNumber.getValue() <= chests) {
             final String text = chests + " minecart chests";
             drawString(text, getX(), getY(), rainbow.getValue() ? IRenderer.rainbow() : Color.WHITE);

--- a/ares-fabric-1.17/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric-1.17/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -77,6 +77,7 @@ public class AresMod extends Ares {
                 // hud
                 Armor.class,
                 ChestCount.class,
+                MinecartCount.class,
                 Coordinates.class,
                 CrystalCount.class,
                 ModuleList.class,

--- a/ares-fabric-1.17/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-fabric-1.17/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
@@ -24,7 +24,7 @@ public class MinecartCount extends HudElement {
             = register(new IntegerSetting("Min count ", 1, 1, 20));
 
     public MinecartCount() {
-        super(100, 60, 0, FONT_RENDERER.getFontHeight());
+        super(100, 60, 0, 5);
     }
 
     public void draw() {

--- a/ares-fabric-1.17/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-fabric-1.17/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
@@ -1,4 +1,4 @@
-package dev.tigr.ares.forge.impl.modules.hud.elements;
+package dev.tigr.ares.fabric.impl.modules.hud.elements;
 
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
@@ -7,8 +7,10 @@ import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
 import dev.tigr.ares.core.util.render.Color;
 import dev.tigr.ares.core.util.render.IRenderer;
-import dev.tigr.ares.forge.impl.modules.hud.HudElement;
-import net.minecraft.entity.item.EntityMinecartChest;
+import dev.tigr.ares.fabric.impl.modules.hud.HudElement;
+import net.minecraft.entity.vehicle.ChestMinecartEntity;
+
+import java.util.stream.StreamSupport;
 
 /**
  * @author UberRipper
@@ -26,8 +28,8 @@ public class MinecartCount extends HudElement {
     }
 
     public void draw() {
-        final int chests = (int) MC.world.loadedEntityList.stream()
-                .filter(Entity -> Entity instanceof EntityMinecartChest).count();
+        int chests = (int) StreamSupport.stream(MC.world.getEntities().spliterator(),false).
+                filter(entity -> entity instanceof ChestMinecartEntity).count();
         if (minimumNotificationNumber.getValue() <= chests) {
             final String text = chests + " minecart chests";
             drawString(text, getX(), getY(), rainbow.getValue() ? IRenderer.rainbow() : Color.WHITE);

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/AresMod.java
@@ -77,6 +77,7 @@ public class AresMod extends Ares {
                 // hud
                 Armor.class,
                 ChestCount.class,
+                MinecartCount.class,
                 Coordinates.class,
                 CrystalCount.class,
                 ModuleList.class,

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
@@ -23,7 +23,7 @@ public class MinecartCount extends HudElement {
             = register(new IntegerSetting("Min count ", 1, 1, 20));
 
     public MinecartCount() {
-        super(100, 60, 0, FONT_RENDERER.getFontHeight());
+        super(100, 60, 0, 5);
     }
 
     public void draw() {

--- a/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-fabric/src/main/java/dev/tigr/ares/fabric/impl/modules/hud/elements/MinecartCount.java
@@ -1,14 +1,15 @@
-package dev.tigr.ares.forge.impl.modules.hud.elements;
+package dev.tigr.ares.fabric.impl.modules.hud.elements;
 
 import dev.tigr.ares.core.feature.module.Category;
 import dev.tigr.ares.core.feature.module.Module;
 import dev.tigr.ares.core.setting.Setting;
 import dev.tigr.ares.core.setting.settings.BooleanSetting;
 import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
+import dev.tigr.ares.fabric.impl.modules.hud.HudElement;
 import dev.tigr.ares.core.util.render.Color;
 import dev.tigr.ares.core.util.render.IRenderer;
-import dev.tigr.ares.forge.impl.modules.hud.HudElement;
-import net.minecraft.entity.item.EntityMinecartChest;
+import net.minecraft.entity.vehicle.ChestMinecartEntity;
+import java.util.stream.StreamSupport;
 
 /**
  * @author UberRipper
@@ -26,8 +27,8 @@ public class MinecartCount extends HudElement {
     }
 
     public void draw() {
-        final int chests = (int) MC.world.loadedEntityList.stream()
-                .filter(Entity -> Entity instanceof EntityMinecartChest).count();
+        int chests = (int) StreamSupport.stream(MC.world.getEntities().spliterator(),false).
+                filter(entity -> entity instanceof ChestMinecartEntity).count();
         if (minimumNotificationNumber.getValue() <= chests) {
             final String text = chests + " minecart chests";
             drawString(text, getX(), getY(), rainbow.getValue() ? IRenderer.rainbow() : Color.WHITE);

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/AresMod.java
@@ -106,6 +106,7 @@ public class AresMod extends Ares {
                 // hud
                 Armor.class,
                 ChestCount.class,
+                MinecartCount.class,
                 Coordinates.class,
                 CrystalCount.class,
                 InvPreview.class,

--- a/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/hud/elements/MinecartCount.java
+++ b/ares-forge/src/main/java/dev/tigr/ares/forge/impl/modules/hud/elements/MinecartCount.java
@@ -1,0 +1,37 @@
+package dev.tigr.ares.forge.impl.modules.hud.elements;
+
+import dev.tigr.ares.core.feature.module.Category;
+import dev.tigr.ares.core.feature.module.Module;
+import dev.tigr.ares.core.setting.Setting;
+import dev.tigr.ares.core.setting.settings.BooleanSetting;
+import dev.tigr.ares.core.setting.settings.numerical.IntegerSetting;
+import dev.tigr.ares.core.util.render.Color;
+import dev.tigr.ares.core.util.render.IRenderer;
+import dev.tigr.ares.forge.impl.modules.hud.HudElement;
+import net.minecraft.entity.item.EntityMinecartChest;
+
+/**
+ * @author UberRipper
+ */
+@Module.Info(name = "MenecartsCount",
+        description = "Lists the amount of minecarts in your render distance, useful for hunting stashes",
+        category = Category.HUD)
+public class MinecartCount extends HudElement {
+    private final Setting<Boolean> rainbow = register(new BooleanSetting("Rainbow", false));
+    private final Setting<Integer> minimumNotificationNumber
+            = register(new IntegerSetting("Min count ", 1, 1, 20));
+
+    public MinecartCount() {
+        super(100, 60, 0, FONT_RENDERER.getFontHeight());
+    }
+
+    public void draw() {
+        final int chests = (int) MC.world.loadedEntityList.stream()
+                .filter(Entity -> Entity instanceof EntityMinecartChest).count();
+        if (minimumNotificationNumber.getValue() <= chests) {
+            final String text = chests + " minecart chests";
+            drawString(text, getX(), getY(), rainbow.getValue() ? IRenderer.rainbow() : Color.WHITE);
+            setWidth((int) FONT_RENDERER.getStringWidth(text) + 1);
+        }
+    }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
minecart chest count as discussed in the discord. Attaching the message below: 
```
... Allerting the player of multiple mine carts in the close location. Aka stashes like in this video https://youtu.be/Ny0VruD8cVk ...
```

**Additional context**
tested and it works, added a minimum trigger, so it could be used as a 1 off notification